### PR TITLE
want simple ELF interpreter for loader programs

### DIFF
--- a/src/hole.rs
+++ b/src/hole.rs
@@ -1,0 +1,28 @@
+use std::io::Read;
+use std::cmp::min;
+
+pub struct Hole {
+    cursor: usize // amount remaining
+}
+
+impl Hole {
+    pub fn new(sz: usize) -> Self {
+        Self {
+            cursor: sz
+        }
+    }
+}
+
+impl Read for Hole {
+    fn read(&mut self, buf: &mut [u8]) -> std::io::Result<usize> {
+        if (self.cursor == 0) {
+            return Ok(0)
+        }
+        let l = min(buf.len(), self.cursor);
+        for slot in &mut buf[0 .. l] {
+            *slot = 0;
+        }
+        self.cursor -= l;
+        Ok(l)
+    }
+}


### PR DESCRIPTION
This generates an image that boots.  There are a few bits mixed together here, and because the code was not already formatted I was not able to use rustfmt to format my changes without creating a lot of spurious garbage.  The pieces are:

1. A `Hole` type that is basically just a variant of `std::io::Repeat` that will return a fixed number of bytes to a consumer.  This should be a separate crate; I was surprised not to find one on crates.io.  Maybe we can use take() instead somehow?
2. The actual ELF interpretation, which chains together Readers for each chunk of data or hole.  We don't include empty segments at the beginning (shouldn't be any) or end (typically BSS), and we coalesce any in the middle.
3. Some debugging improvements because I can't cope with decimal.

I also moved the APOB to the address the kernel expects, and removed the fixed flash location for the loader image (it's not needed).  These changes are not really germane to making ELF interpretation work, though.

Obviously the assertions should not be assertions, but they illustrate the basic checks I'd like to make on the image we're handed.