### PR TITLE
static_config: Increase the BHD size to 3.9375 MiB.

### DIFF
--- a/src/static_config.rs
+++ b/src/static_config.rs
@@ -7,7 +7,7 @@ pub(crate) const PSP_BEGINNING: Location = 0x12_0000;
 pub(crate) const PSP_END: Location = 0x12_0000 + 0x12_0000;
 
 pub(crate) const BHD_BEGINNING: Location = 0x24_0000;
-pub(crate) const BHD_END: Location = 0x24_0000 + 0x8_0000;
+pub(crate) const BHD_END: Location = 0x24_0000 + 0x3f_0000;
 
 // Note: This must not be changed.
 // It's hardcoded in the PSP bootloader and in amd-efs's "create" function.


### PR DESCRIPTION
This increases the size of the BHD to 3.9375 MiB.

That's close to the maximum size so far.
The reason is that the directory header stores a max directory size (i.e. directory allocation) in 10 bits (in field `max_size` in struct `DirectoryAdditionalInfo`, see `ondisk.rs`). This `max_size` is stored in units of `4 kiB`.

That makes the maximal directory size just below `(2**10) * 4096 B = 4 MiB`. The last possible value to store is `(2**10 - 1) * 4096 B = 3.99609375 MiB`. But we also have to consider the flash block size.

If, in the future, we want to store bigger blobs, we have to store them outside the directory (which we easily can, by passing a custom location to the respective adder fn).

