### PR TITLE
main: Make Efh location compatible with Genoa.

### DIFF
--- a/src/main.rs
+++ b/src/main.rs
@@ -2523,6 +2523,7 @@ fn main() -> std::io::Result<()> {
 	let mut efs = match Efs::<_, ERASABLE_BLOCK_SIZE>::create(
 		storage,
 		host_processor_generation,
+		static_config::EFH_BEGINNING,
 		Some(IMAGE_SIZE),
 	) {
 		Ok(efs) => efs,

--- a/src/static_config.rs
+++ b/src/static_config.rs
@@ -3,12 +3,12 @@ use amd_flash::Location;
 
 /* Coarse-grained flash locations (in Byte) */
 
-pub(crate) const PSP_BEGINNING: Location = 0x12_0000;
-pub(crate) const PSP_END: Location = 0x12_0000 + 0x12_0000;
+// Note: This must not be changed.
+// It's hardcoded in the PSP bootloader.
+pub(crate) const EFH_BEGINNING: Location = 0x2_0000;
+
+pub(crate) const PSP_BEGINNING: Location = 0xD_0000;
+pub(crate) const PSP_END: Location = 0xD_0000 + 0x12_0000;
 
 pub(crate) const BHD_BEGINNING: Location = 0x24_0000;
 pub(crate) const BHD_END: Location = 0x24_0000 + 0x3f_0000;
-
-// Note: This must not be changed.
-// It's hardcoded in the PSP bootloader and in amd-efs's "create" function.
-pub(crate) const EFH_BEGINNING: Location = 0xFA_0000;


### PR DESCRIPTION
AMD keeps moving the Efh around. First it was recommended at 0x2_0000, then at 0xFA_0000, now it's recommended at 0x2_0000 again.

Fine. Move it to 0x2_0000.
