### PR TITLE
Reset image relocation

### DIFF
--- a/src/static_config.rs
+++ b/src/static_config.rs
@@ -8,7 +8,10 @@ pub(crate) const PSP_BEGINNING: Location = 0x12_0000;
 pub(crate) const PSP_END: Location = 0x12_0000 + 0x12_0000;
 
 pub(crate) const BHD_BEGINNING: Location = 0x24_0000;
-pub(crate) const BHD_END: Location = 0x24_0000 + 0x3f_0000;
+pub(crate) const BHD_END: Location = 0x24_0000 + 0xA_0000;
+
+pub(crate) const RESET_IMAGE_BEGINNING: Location = 0x30_0000;
+pub(crate) const RESET_IMAGE_END: Location = 0xFA_0000;
 
 // Note: This must not be changed.
 // It's hardcoded in the PSP bootloader and in amd-efs's "create" function.


### PR DESCRIPTION
Fixes issue #15 "The size of the reset image is limited to about 3.2 MiB".

The limit is now 12.625 MiB.