### PR TITLE
rust-toolchain: Update to nightly-2022-05-13.

### DIFF
--- a/rust-toolchain
+++ b/rust-toolchain
@@ -1,3 +1,3 @@
 [toolchain]
-channel = "nightly-2021-09-01"
+channel = "nightly-2022-05-13"
 components = [ "rustfmt", "rust-src" ]


### PR DESCRIPTION
Otherwise, you get this:

```
amd-host-image-builder$ make
make -C nanobl-rs
make[1]: Entering directory '/home/dannym/src/Oxide/crates/main/amd-host-image-builder/nanobl-rs'
cargo build -Z unstable-options --out-dir obj 
    Finished dev [optimized + debuginfo] target(s) in 1.70s
make[1]: Leaving directory '/home/dannym/src/Oxide/crates/main/amd-host-image-builder/nanobl-rs'
cargo run -- -c etc/Milan.json -r nanobl-rs/obj/nanobl-rs.elf -o Milan.img
    Updating git repository `ssh://git@github.com/oxidecomputer/amd-apcb.git`
error: failed to get `amd-apcb` as a dependency of package `amd-host-image-builder v0.1.0 (/home/dannym/src/Oxide/crates/main/amd-host-image-builder)`

Caused by:
  failed to load source for dependency `amd-apcb`

Caused by:
  Unable to update ssh://git@github.com/oxidecomputer/amd-apcb.git?rev=7f637fa003684385c59e8ed360da5ac85e5e2c88

Caused by:
  failed to parse manifest at `/usr/local/cargo/git/checkouts/amd-apcb-3378037d52871b9d/7f637fa/Cargo.toml`

Caused by:
  namespaced features with the `dep:` prefix are only allowed on the nightly channel and requires the `-Z namespaced-features` flag on the command-line
make: *** [Makefile:5: all] Error 101
```
since the `dep:` feature is too new.
