### PR TITLE
SerdePspEntry: Make source an enum, too.

### DIFF
--- a/amd-host-image-builder-config/src/lib.rs
+++ b/amd-host-image-builder-config/src/lib.rs
@@ -31,19 +31,16 @@ pub type Result<T> = core::result::Result<T, Error>;
 
 #[derive(serde::Serialize, serde::Deserialize, schemars::JsonSchema)]
 #[serde(deny_unknown_fields)]
-pub enum SerdePspDirectoryEntryBody {
-	Value,
-	Blob {
-		#[serde(default)]
-		flash_location: Option<Location>,
-		#[serde(default)]
-		size: Option<u32>, // FIXME u64
-	}
+pub struct SerdePspDirectoryEntryBlob {
+	#[serde(default)]
+	pub flash_location: Option<Location>,
+	#[serde(default)]
+	pub size: Option<u32>, // FIXME u64
 }
 
-impl Default for SerdePspDirectoryEntryBody {
+impl Default for SerdePspDirectoryEntryBlob {
 	fn default() -> Self {
-		Self::Blob {
+		Self {
 			flash_location: None,
 			size: None,
 		}
@@ -56,8 +53,8 @@ pub struct SerdePspDirectoryEntry {
 	#[serde(flatten)]
 	pub attrs: PspDirectoryEntryAttrs,
 	#[serde(flatten)]
-	#[serde(default)]
-	pub body: SerdePspDirectoryEntryBody,
+	//#[serde(default)]
+	pub blob: Option<SerdePspDirectoryEntryBlob>,
 }
 
 
@@ -76,17 +73,15 @@ pub struct SerdePspEntry {
 }
 
 #[derive(serde::Serialize, serde::Deserialize, schemars::JsonSchema)]
-#[serde(rename = "BhdDirectoryEntryBody")]
+#[serde(rename = "BhdDirectoryEntryBlob")]
 #[serde(deny_unknown_fields)]
-pub enum SerdeBhdDirectoryEntryBody {
-	Blob {
-		#[serde(default)]
-		flash_location: Option<Location>,
-		#[serde(default)]
-		size: Option<u32>, // FIXME u64 ?
-		#[serde(default)]
-		ram_destination_address: Option<u64>,
-	}
+pub struct SerdeBhdDirectoryEntryBlob {
+	#[serde(default)]
+	pub flash_location: Option<Location>,
+	#[serde(default)]
+	pub size: Option<u32>, // FIXME u64 ?
+	#[serde(default)]
+	pub ram_destination_address: Option<u64>,
 }
 
 #[derive(serde::Serialize, serde::Deserialize, schemars::JsonSchema)]
@@ -96,12 +91,12 @@ pub struct SerdeBhdDirectoryEntry {
 	pub attrs: BhdDirectoryEntryAttrs,
 	#[serde(flatten)]
 	#[serde(default)]
-	pub body: SerdeBhdDirectoryEntryBody,
+	pub blob: Option<SerdeBhdDirectoryEntryBlob>,
 }
 
-impl Default for SerdeBhdDirectoryEntryBody {
+impl Default for SerdeBhdDirectoryEntryBlob {
 	fn default() -> Self {
-		Self::Blob {
+		Self {
 			flash_location: None,
 			size: None,
 			ram_destination_address: None,

--- a/etc/Milan.json
+++ b/etc/Milan.json
@@ -8,9 +8,7 @@
 						"BlobFile": "AmdPubKey.tkn"
 					},
 					"target": {
-						"type": "AmdPublicKey",
-						"Blob": {
-						}
+						"type": "AmdPublicKey"
 					}
 				},
 				{
@@ -18,9 +16,7 @@
 						"BlobFile": "PspBootLoader.sbin"
 					},
 					"target": {
-						"type": "PspBootloader",
-						"Blob": {
-						}
+						"type": "PspBootloader"
 					}
 				},
 				{
@@ -28,9 +24,7 @@
 						"BlobFile": "PspRecoveryBootLoader.sbin"
 					},
 					"target": {
-						"type": "PspRecoveryBootloader",
-						"Blob": {
-						}
+						"type": "PspRecoveryBootloader"
 					}
 				},
 				{
@@ -38,9 +32,7 @@
 						"BlobFile": "SmuFirmware.csbin"
 					},
 					"target": {
-						"type": "SmuOffChipFirmware8",
-						"Blob": {
-						}
+						"type": "SmuOffChipFirmware8"
 					}
 				},
 				{
@@ -48,9 +40,7 @@
 						"BlobFile": "SecureDebugToken.stkn"
 					},
 					"target": {
-						"type": "AmdSecureDebugKey",
-						"Blob": {
-						}
+						"type": "AmdSecureDebugKey"
 					}
 				},
 				{
@@ -58,9 +48,7 @@
 						"BlobFile": "AblPubKey.bin"
 					},
 					"target": {
-						"type": "AblPublicKey",
-						"Blob": {
-						}
+						"type": "AblPublicKey"
 					}
 				},
 				{
@@ -68,8 +56,7 @@
 						"Value": 1
 					},
 					"target": {
-						"type": "PspSoftFuseChain",
-						"Value": null
+						"type": "PspSoftFuseChain"
 					}
 				},
 				{
@@ -77,9 +64,7 @@
 						"BlobFile": "SmuFirmware2.csbin"
 					},
 					"target": {
-						"type": "SmuOffChipFirmware12",
-						"Blob": {
-						}
+						"type": "SmuOffChipFirmware12"
 					}
 				},
 				{
@@ -87,9 +72,7 @@
 						"BlobFile": "SecureDebugUnlock.sbin"
 					},
 					"target": {
-						"type": "PspEarlySecureUnlockDebugImage",
-						"Blob": {
-						}
+						"type": "PspEarlySecureUnlockDebugImage"
 					}
 				},
 				{
@@ -97,9 +80,7 @@
 						"BlobFile": "PspIkek.bin"
 					},
 					"target": {
-						"type": "WrappedIkek",
-						"Blob": {
-						}
+						"type": "WrappedIkek"
 					}
 				},
 				{
@@ -107,9 +88,7 @@
 						"BlobFile": "SecureEmptyToken.bin"
 					},
 					"target": {
-						"type": "PspTokenUnlockData",
-						"Blob": {
-						}
+						"type": "PspTokenUnlockData"
 					}
 				},
 				{
@@ -117,9 +96,7 @@
 						"BlobFile": "RsmuSecPolicy.sbin"
 					},
 					"target": {
-						"type": "SecurityPolicyBinary",
-						"Blob": {
-						}
+						"type": "SecurityPolicyBinary"
 					}
 				},
 				{
@@ -127,9 +104,7 @@
 						"BlobFile": "Mp5.csbin"
 					},
 					"target": {
-						"type": "Mp5Firmware",
-						"Blob": {
-						}
+						"type": "Mp5Firmware"
 					}
 				},
 				{
@@ -137,9 +112,7 @@
 						"BlobFile": "AgesaBootloader_U_prod.csbin"
 					},
 					"target": {
-						"type": "Abl0",
-						"Blob": {
-						}
+						"type": "Abl0"
 					}
 				},
 				{
@@ -147,9 +120,7 @@
 						"BlobFile": "PhyFw.sbin"
 					},
 					"target": {
-						"type": "DxioPhySramFirmware",
-						"Blob": {
-						}
+						"type": "DxioPhySramFirmware"
 					}
 				},
 				{
@@ -157,9 +128,7 @@
 						"BlobFile": "PSP-Key-DB.sbin"
 					},
 					"target": {
-						"type": "PspBootloaderPublicKeysTable",
-						"Blob": {
-						}
+						"type": "PspBootloaderPublicKeysTable"
 					}
 				}
 			]
@@ -4812,9 +4781,7 @@
 					"target": {
 						"type": "ApcbBackup",
 						"sub_program": 1,
-						"Blob": {
-							"size": 9216
-						}
+						"size": 9216
 					}
 				},
 				{
@@ -4824,9 +4791,7 @@
 					"target": {
 						"type": "PmuFirmwareInstructions",
 						"instance": 1,
-						"sub_program": 1,
-						"Blob": {
-						}
+						"sub_program": 1
 					}
 				},
 				{
@@ -4836,9 +4801,7 @@
 					"target": {
 						"type": "PmuFirmwareData",
 						"instance": 1,
-						"sub_program": 1,
-						"Blob": {
-						}
+						"sub_program": 1
 					}
 				},
 				{
@@ -4848,9 +4811,7 @@
 					"target": {
 						"type": "PmuFirmwareInstructions",
 						"instance": 2,
-						"sub_program": 1,
-						"Blob": {
-						}
+						"sub_program": 1
 					}
 				},
 				{
@@ -4860,9 +4821,7 @@
 					"target": {
 						"type": "PmuFirmwareData",
 						"instance": 2,
-						"sub_program": 1,
-						"Blob": {
-						}
+						"sub_program": 1
 					}
 				},
 				{
@@ -4872,9 +4831,7 @@
 					"target": {
 						"type": "PmuFirmwareInstructions",
 						"instance": 4,
-						"sub_program": 1,
-						"Blob": {
-						}
+						"sub_program": 1
 					}
 				},
 				{
@@ -4884,9 +4841,7 @@
 					"target": {
 						"type": "PmuFirmwareData",
 						"instance": 4,
-						"sub_program": 1,
-						"Blob": {
-						}
+						"sub_program": 1
 					}
 				},
 				{
@@ -4896,9 +4851,7 @@
 					"target": {
 						"type": "PmuFirmwareInstructions",
 						"instance": 5,
-						"sub_program": 1,
-						"Blob": {
-						}
+						"sub_program": 1
 					}
 				},
 				{
@@ -4908,9 +4861,7 @@
 					"target": {
 						"type": "PmuFirmwareData",
 						"instance": 5,
-						"sub_program": 1,
-						"Blob": {
-						}
+						"sub_program": 1
 					}
 				},
 				{
@@ -4920,9 +4871,7 @@
 					"target": {
 						"type": "PmuFirmwareInstructions",
 						"instance": 8,
-						"sub_program": 1,
-						"Blob": {
-						}
+						"sub_program": 1
 					}
 				},
 				{
@@ -4932,9 +4881,7 @@
 					"target": {
 						"type": "PmuFirmwareData",
 						"instance": 8,
-						"sub_program": 1,
-						"Blob": {
-						}
+						"sub_program": 1
 					}
 				},
 				{
@@ -4944,9 +4891,7 @@
 					"target": {
 						"type": "PmuFirmwareData",
 						"instance": 9,
-						"sub_program": 1,
-						"Blob": {
-						}
+						"sub_program": 1
 					}
 				},
 				{
@@ -4956,9 +4901,7 @@
 					"target": {
 						"type": "PmuFirmwareData",
 						"instance": 9,
-						"sub_program": 1,
-						"Blob": {
-						}
+						"sub_program": 1
 					}
 				},
 				{
@@ -4968,9 +4911,7 @@
 					"target": {
 						"type": "PmuFirmwareInstructions",
 						"instance": 10,
-						"sub_program": 1,
-						"Blob": {
-						}
+						"sub_program": 1
 					}
 				},
 				{
@@ -4980,9 +4921,7 @@
 					"target": {
 						"type": "PmuFirmwareData",
 						"instance": 10,
-						"sub_program": 1,
-						"Blob": {
-						}
+						"sub_program": 1
 					}
 				}
 		]

--- a/etc/Rome.json
+++ b/etc/Rome.json
@@ -8,9 +8,7 @@
 						"BlobFile": "AmdPubKey.tkn"
 					},
 					"target": {
-						"type": "AmdPublicKey",
-						"Blob": {
-						}
+						"type": "AmdPublicKey"
 					}
 				},
 				{
@@ -18,9 +16,7 @@
 						"BlobFile": "PspBootLoader.sbin"
 					},
 					"target": {
-						"type": "PspBootloader",
-						"Blob": {
-						}
+						"type": "PspBootloader"
 					}
 				},
 				{
@@ -28,9 +24,7 @@
 						"BlobFile": "PspRecoveryBootLoader.sbin"
 					},
 					"target": {
-						"type": "PspRecoveryBootloader",
-						"Blob": {
-						}
+						"type": "PspRecoveryBootloader"
 					}
 				},
 				{
@@ -38,9 +32,7 @@
 						"BlobFile": "SmuFirmware.csbin"
 					},
 					"target": {
-						"type": "SmuOffChipFirmware8",
-						"Blob": {
-						}
+						"type": "SmuOffChipFirmware8"
 					}
 				},
 				{
@@ -48,9 +40,7 @@
 						"BlobFile": "AblPubKey.bin"
 					},
 					"target": {
-						"type": "AblPublicKey",
-						"Blob": {
-						}
+						"type": "AblPublicKey"
 					}
 				},
 				{
@@ -67,9 +57,7 @@
 						"BlobFile": "SmuFirmware2.csbin"
 					},
 					"target": {
-						"type": "SmuOffChipFirmware12",
-						"Blob": {
-						}
+						"type": "SmuOffChipFirmware12"
 					}
 				},
 				{
@@ -77,9 +65,7 @@
 						"BlobFile": "SecureDebugUnlock.sbin"
 					},
 					"target": {
-						"type": "PspEarlySecureUnlockDebugImage",
-						"Blob": {
-						}
+						"type": "PspEarlySecureUnlockDebugImage"
 					}
 				},
 				{
@@ -87,9 +73,7 @@
 						"BlobFile": "PspIkek.bin"
 					},
 					"target": {
-						"type": "WrappedIkek",
-						"Blob": {
-						}
+						"type": "WrappedIkek"
 					}
 				},
 				{
@@ -97,9 +81,7 @@
 						"BlobFile": "SecureEmptyToken.bin"
 					},
 					"target": {
-						"type": "PspTokenUnlockData",
-						"Blob": {
-						}
+						"type": "PspTokenUnlockData"
 					}
 				},
 				{
@@ -107,9 +89,7 @@
 						"BlobFile": "RsmuSecPolicy.sbin"
 					},
 					"target": {
-						"type": "SecurityPolicyBinary",
-						"Blob": {
-						}
+						"type": "SecurityPolicyBinary"
 					}
 				},
 				{
@@ -117,9 +97,7 @@
 						"BlobFile": "Mp5.csbin"
 					},
 					"target": {
-						"type": "Mp5Firmware",
-						"Blob": {
-						}
+						"type": "Mp5Firmware"
 					}
 				},
 				{
@@ -127,9 +105,7 @@
 						"BlobFile": "AgesaBootloader_U_prod.csbin"
 					},
 					"target": {
-						"type": "Abl0",
-						"Blob": {
-						}
+						"type": "Abl0"
 					}
 				},
 				{
@@ -137,9 +113,7 @@
 						"BlobFile": "PhyFw.sbin"
 					},
 					"target": {
-						"type": "DxioPhySramFirmware",
-						"Blob": {
-						}
+						"type": "DxioPhySramFirmware"
 					}
 				},
 				{
@@ -147,9 +121,7 @@
 						"BlobFile": "PhyFwSb4kr.stkn"
 					},
 					"target": {
-						"type": "DxioPhySramPublicKey",
-						"Blob": {
-						}
+						"type": "DxioPhySramPublicKey"
 					}
 				},
 				{
@@ -157,9 +129,7 @@
 						"BlobFile": "Starship-PMU-FW.stkn"
 					},
 					"target": {
-						"type": "PmuPublicKey",
-						"Blob": {
-						}
+						"type": "PmuPublicKey"
 					}
 				}
 			]
@@ -4824,9 +4794,7 @@
 					"target": {
 						"type": "PmuFirmwareInstructions",
 						"instance": 1,
-						"sub_program": 1,
-						"Blob": {
-						}
+						"sub_program": 1
 					}
 				},
 				{
@@ -4836,9 +4804,7 @@
 					"target": {
 						"type": "PmuFirmwareData",
 						"instance": 1,
-						"sub_program": 1,
-						"Blob": {
-						}
+						"sub_program": 1
 					}
 				},
 				{
@@ -4848,9 +4814,7 @@
 					"target": {
 						"type": "PmuFirmwareInstructions",
 						"instance": 2,
-						"sub_program": 1,
-						"Blob": {
-						}
+						"sub_program": 1
 					}
 				},
 				{
@@ -4860,9 +4824,7 @@
 					"target": {
 						"type": "PmuFirmwareData",
 						"instance": 2,
-						"sub_program": 1,
-						"Blob": {
-						}
+						"sub_program": 1
 					}
 				},
 				{
@@ -4872,9 +4834,7 @@
 					"target": {
 						"type": "PmuFirmwareInstructions",
 						"instance": 4,
-						"sub_program": 1,
-						"Blob": {
-						}
+						"sub_program": 1
 					}
 				},
 				{
@@ -4884,9 +4844,7 @@
 					"target": {
 						"type": "PmuFirmwareData",
 						"instance": 4,
-						"sub_program": 1,
-						"Blob": {
-						}
+						"sub_program": 1
 					}
 				},
 				{
@@ -4896,9 +4854,7 @@
 					"target": {
 						"type": "PmuFirmwareInstructions",
 						"instance": 5,
-						"sub_program": 1,
-						"Blob": {
-						}
+						"sub_program": 1
 					}
 				},
 				{
@@ -4908,9 +4864,7 @@
 					"target": {
 						"type": "PmuFirmwareData",
 						"instance": 5,
-						"sub_program": 1,
-						"Blob": {
-						}
+						"sub_program": 1
 					}
 				}
 			]


### PR DESCRIPTION
Previously, PspDirectoryEntry's `source` was always a filename.

That means that for `SoftFuseChain`, which expects a literal value, that was `/dev/null`--and the `target` had a spot for the SOURCE value to use. That's totally weird and makes the seperation of source vs target unclear.

This PR makes `source` an enum with variants `Value` (with a value) and `BlobFile` (with a filename).

Also, I've added the last commit now, which makes `Blob` in `target` optional.