### PR TITLE
build: Work around schemars issue #62.

### DIFF
--- a/build/config_schema.rs
+++ b/build/config_schema.rs
@@ -1,10 +1,19 @@
 use amd_host_image_builder_config::SerdeConfig;
+use schemars::gen::SchemaSettings;
 use std::ffi::OsString;
 use std::fs;
 use std::path::Path;
 
 pub fn generate_config_json_schema(outdir: &OsString) {
-	let schema = schemars::schema_for!(SerdeConfig);
+	let settings = SchemaSettings::default().with(|s| {
+		// Work around schemars issue #62.
+		// Downside: This makes the schema bigger by an order
+		// of magnitude.
+		s.inline_subschemas = true
+	});
+	let gen = settings.into_generator();
+	let schema = gen.into_root_schema_for::<SerdeConfig>();
+
 	let schema_file = Path::new(outdir).join("efs.schema.json");
 	fs::write(schema_file, serde_json::to_string_pretty(&schema).unwrap())
 		.unwrap();


### PR DESCRIPTION
This works around schemars issue #62 https://github.com/GREsau/schemars/issues/62 .

The downside is that it makes the schema an order of magnitude larger (to about 1 MiB).

The upside is that with this workaround the schema covers 100% correctly.

I think that's OK for now.