### PR TITLE
main: increase image size to 32 MiB.

### DIFF
--- a/src/main.rs
+++ b/src/main.rs
@@ -163,7 +163,6 @@ impl FlashImage {
 	}
 }
 
-const IMAGE_SIZE: u32 = 16 * 1024 * 1024;
 const ERASABLE_BLOCK_SIZE: usize = 0x1000;
 type AlignedLocation = ErasableLocation<ERASABLE_BLOCK_SIZE>;
 
@@ -545,11 +544,11 @@ fn main() -> std::io::Result<()> {
 		.write(true)
 		.create(true)
 		.open(filename)?;
-	file.set_len(IMAGE_SIZE.into())?;
+	file.set_len(static_config::IMAGE_SIZE.into())?;
 	let mut storage = FlashImage::new(file, &filename);
 	let mut position: AlignedLocation =
 		0.try_into().map_err(flash_to_io_error)?;
-	while Location::from(position) < IMAGE_SIZE {
+	while Location::from(position) < static_config::IMAGE_SIZE {
 		FlashWrite::<ERASABLE_BLOCK_SIZE>::erase_block(
 			&mut storage,
 			position,
@@ -559,7 +558,7 @@ fn main() -> std::io::Result<()> {
 			.advance(ERASABLE_BLOCK_SIZE)
 			.map_err(flash_to_io_error)?;
 	}
-	assert!(Location::from(position) == IMAGE_SIZE);
+	assert!(Location::from(position) == static_config::IMAGE_SIZE);
 	let path = Path::new(&opts.efs_configuration_filename);
 	let data = std::fs::read_to_string(path)?;
 	let config: SerdeConfig =
@@ -578,7 +577,7 @@ fn main() -> std::io::Result<()> {
 		storage,
 		host_processor_generation,
 		static_config::EFH_BEGINNING(host_processor_generation),
-		Some(IMAGE_SIZE),
+		Some(static_config::IMAGE_SIZE),
 	) {
 		Ok(efs) => efs,
 		Err(e) => {

--- a/src/static_config.rs
+++ b/src/static_config.rs
@@ -1,6 +1,8 @@
 use amd_efs::ProcessorGeneration;
 use amd_flash::Location;
 
+pub(crate) const IMAGE_SIZE: u32 = 32 * 1024 * 1024;
+
 /* Coarse-grained flash locations (in Byte) */
 
 pub(crate) const PSP_BEGINNING: Location = 0x12_0000;
@@ -9,8 +11,8 @@ pub(crate) const PSP_END: Location = 0x12_0000 + 0x12_0000;
 pub(crate) const BHD_BEGINNING: Location = 0x24_0000;
 pub(crate) const BHD_END: Location = 0x24_0000 + 0xA_0000;
 
-pub(crate) const RESET_IMAGE_BEGINNING: Location = 0x30_0000;
-pub(crate) const RESET_IMAGE_END: Location = 0xFA_0000;
+pub(crate) const RESET_IMAGE_BEGINNING: Location = 0x100_0000;
+pub(crate) const RESET_IMAGE_END: Location = 0x200_0000;
 
 // Note: This must not be changed.
 // It's hardcoded in the PSP bootloader and in amd-efs's "create" function.


### PR DESCRIPTION
Fixes <https://github.com/oxidecomputer/amd-host-image-builder/issues/58>.