### PR TITLE
etc: Add now-mandatory token "MemPmuBistTestSelect".

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -14,7 +14,7 @@ dependencies = [
 [[package]]
 name = "amd-apcb"
 version = "0.1.0"
-source = "git+ssh://git@github.com/oxidecomputer/amd-apcb.git?rev=c56383b29a557c0611a00b2bd61387c9fb23f3eb#c56383b29a557c0611a00b2bd61387c9fb23f3eb"
+source = "git+ssh://git@github.com/oxidecomputer/amd-apcb.git?rev=1c076f1caefdbcd02d869282ca64c52330acd6cd#1c076f1caefdbcd02d869282ca64c52330acd6cd"
 dependencies = [
  "byteorder",
  "four-cc",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -7,7 +7,7 @@ edition = "2018"
 # See more keys and their definitions at https://doc.rust-lang.org/cargo/reference/manifest.html
 
 [dependencies]
-amd-apcb = { git = "ssh://git@github.com/oxidecomputer/amd-apcb.git", rev = "c56383b29a557c0611a00b2bd61387c9fb23f3eb", features = ["serde", "schemars"] }
+amd-apcb = { git = "ssh://git@github.com/oxidecomputer/amd-apcb.git", rev = "1c076f1caefdbcd02d869282ca64c52330acd6cd", features = ["serde", "schemars"] }
 amd-efs = { git = "ssh://git@github.com/oxidecomputer/amd-efs.git", rev = "6eda4d6fa0e477f6ff061f85dcd3c29d3f4522fe", features = ["std", "serde", "schemars"] }
 amd-flash = { git = "ssh://git@github.com/oxidecomputer/amd-flash.git", branch = "main" }
 goblin = { version = "0.4", features = ["elf64", "endian_fd"] }
@@ -22,7 +22,7 @@ valico = "2"
 pathsep="0.1.1"
 
 [build-dependencies]
-amd-apcb = { git = "ssh://git@github.com/oxidecomputer/amd-apcb.git", rev = "c56383b29a557c0611a00b2bd61387c9fb23f3eb", features = ["serde", "schemars"] }
+amd-apcb = { git = "ssh://git@github.com/oxidecomputer/amd-apcb.git", rev = "1c076f1caefdbcd02d869282ca64c52330acd6cd", features = ["serde", "schemars"] }
 amd-efs = { git = "ssh://git@github.com/oxidecomputer/amd-efs.git", rev = "6eda4d6fa0e477f6ff061f85dcd3c29d3f4522fe", features = ["std", "serde", "schemars"] }
 amd-host-image-builder-config = { path = "amd-host-image-builder-config" }
 schemars = "0.8.8"

--- a/amd-host-image-builder-config/Cargo.toml
+++ b/amd-host-image-builder-config/Cargo.toml
@@ -6,7 +6,7 @@ edition = "2018"
 # See more keys and their definitions at https://doc.rust-lang.org/cargo/reference/manifest.html
 
 [dependencies]
-amd-apcb = { git = "ssh://git@github.com/oxidecomputer/amd-apcb.git", rev = "c56383b29a557c0611a00b2bd61387c9fb23f3eb", features = ["serde", "schemars"] }
+amd-apcb = { git = "ssh://git@github.com/oxidecomputer/amd-apcb.git", rev = "1c076f1caefdbcd02d869282ca64c52330acd6cd", features = ["serde", "schemars"] }
 amd-efs = { git = "ssh://git@github.com/oxidecomputer/amd-efs.git", rev = "6eda4d6fa0e477f6ff061f85dcd3c29d3f4522fe", features = ["std", "serde", "schemars"] }
 amd-flash = { git = "ssh://git@github.com/oxidecomputer/amd-flash.git", branch = "main" }
 schemars = "0.8.8"

--- a/etc/milan-ethanol-x.efs.json5
+++ b/etc/milan-ethanol-x.efs.json5
@@ -4316,6 +4316,15 @@
 										},
 										{
 											Byte: {
+												MemPmuBistTestSelect: {
+													algorithm_1: true,
+													algorithm_2: true,
+													algorithm_3: true,
+												}
+											}
+										},
+										{
+											Byte: {
 												MemCpuVrefRange: 0x00
 											}
 										},

--- a/etc/milan-gimlet-b.efs.json5
+++ b/etc/milan-gimlet-b.efs.json5
@@ -4316,6 +4316,15 @@
 										},
 										{
 											Byte: {
+												MemPmuBistTestSelect: {
+													algorithm_1: true,
+													algorithm_2: true,
+													algorithm_3: true,
+												}
+											}
+										},
+										{
+											Byte: {
 												MemCpuVrefRange: 0x00
 											}
 										},


### PR DESCRIPTION
Makes MilanPI 1.0.0.9 firmware boot.