### PR TITLE
improve buildomat git URL handling

### DIFF
--- a/.github/buildomat/jobs/build-and-test.sh
+++ b/.github/buildomat/jobs/build-and-test.sh
@@ -27,48 +27,29 @@ cargo --version
 # The token authentication mechanism that affords us access to other private
 # repositories requires that we use HTTPS URLs for GitHub, rather than SSH.
 #
-# First, doctor the git submodule configuration:
-#
-sed -i -e 's,git@github.com:,https://github.com/,g' .gitmodules
-git submodule sync
-git submodule update --init
-
-#
-# Next, create a git(1) wrapper program.  This program will attempt to convert
-# any SSH URLs found in the arguments to HTTPS URLs and then exec the real git.
-#
-mkdir -p /work/workaround
-cat >/work/workaround/git <<'EOF'
-#!/bin/bash
-args=()
-while (( $# > 0 )); do
-	val="$1"
-	val="${val//ssh:\/\/git@/https:\/\/}"
-	val="${val//git@github.com:/https:\/\/github.com\/}"
-	if [[ "$val" != "$1" ]]; then
-		printf 'REGRET: transformed "%s" -> "%s"\n' "$1" "$val" >&2
-	fi
-	args+=( "$val" )
-	shift
+override_urls=(
+    'git://github.com/'
+    'git@github.com:'
+    'ssh://github.com/'
+    'ssh://git@github.com/'
+)
+for (( i = 0; i < ${#override_urls[@]}; i++ )); do
+	git config --add --global url.https://github.com/.insteadOf \
+	    "${override_urls[$i]}"
 done
-#
-# Remove the workaround directory from PATH before executing the real git:
-#
-export PATH=${PATH/#\/work\/workaround:/}
-exec /usr/bin/git "${args[@]}"
-EOF
-chmod +x /work/workaround/git
-export PATH="/work/workaround:$PATH"
 
 #
-# Finally, require that cargo use the git CLI -- or, rather, our wrapper! --
-# instead of the built-in support.  This achieves two things: first, SSH URLs
-# should be transformed on fetch without requiring Cargo.toml rewriting, which
-# is especially difficult in transitive dependencies; second, Cargo does not
-# seem willing on its own to look in ~/.netrc and find the temporary token that
-# buildomat generates for our job, so we must use git which uses curl.
+# Require that cargo use the git CLI instead of the built-in support.  This
+# achieves two things: first, SSH URLs should be transformed on fetch without
+# requiring Cargo.toml rewriting, which is especially difficult in transitive
+# dependencies; second, Cargo does not seem willing on its own to look in
+# ~/.netrc and find the temporary token that buildomat generates for our job,
+# so we must use git which uses curl.
 #
 export CARGO_NET_GIT_FETCH_WITH_CLI=true
+
+git submodule sync
+git submodule update --init
 
 banner test
 ptime -m cargo test --verbose

--- a/README.md
+++ b/README.md
@@ -6,10 +6,9 @@ This tool builds a flash image for an AMD Zen system.
 
 First, please set up the environment such that you have the required AMD firmware and also the bootloader you want to use.
 
-This is done by executing the following commands:
+This is done by executing the following command:
 
-    git submodule init
-    git submodule update
+    git submodule update --init
 
 # Usage
 


### PR DESCRIPTION
Thanks to @nathanaelhuffman for putting me onto a less eccentric way to deal with SSH URLs in git submodules and cargo dependencies.  This has `git` do the translation on its own, rather than creating a ridiculous `git` wrapper.