### PR TITLE
main: Adapt to runtime erase block size of amd-efs and amd-flash.

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -36,7 +36,7 @@ dependencies = [
 [[package]]
 name = "amd-efs"
 version = "0.1.0"
-source = "git+ssh://git@github.com/oxidecomputer/amd-efs.git?rev=c6fefb9797d992fb9c6f757c2f44c720bf6cad95#c6fefb9797d992fb9c6f757c2f44c720bf6cad95"
+source = "git+ssh://git@github.com/oxidecomputer/amd-efs.git?rev=e2a599e2f5b580ce1753c02b06ab019375ca3596#e2a599e2f5b580ce1753c02b06ab019375ca3596"
 dependencies = [
  "amd-flash",
  "byteorder",
@@ -55,7 +55,7 @@ dependencies = [
 [[package]]
 name = "amd-flash"
 version = "0.1.0"
-source = "git+ssh://git@github.com/oxidecomputer/amd-flash.git?branch=main#5e489e7df24b108569ab7ded301a00beb090a359"
+source = "git+ssh://git@github.com/oxidecomputer/amd-flash.git?rev=90207243874f18cfc8b9fc1fd8f030dca4509458#90207243874f18cfc8b9fc1fd8f030dca4509458"
 
 [[package]]
 name = "amd-host-image-builder"
@@ -70,6 +70,7 @@ dependencies = [
  "pathsep",
  "schemars",
  "serde_json",
+ "static_assertions",
  "structopt",
  "valico",
 ]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -8,14 +8,15 @@ edition = "2018"
 
 [dependencies]
 amd-apcb = { git = "ssh://git@github.com/oxidecomputer/amd-apcb.git", rev = "70170e08f6d39af5a67de139832718940e628dfe", features = ["serde", "schemars"] }
-amd-efs = { git = "ssh://git@github.com/oxidecomputer/amd-efs.git", rev = "c6fefb9797d992fb9c6f757c2f44c720bf6cad95", features = ["std", "serde", "schemars"] }
-amd-flash = { git = "ssh://git@github.com/oxidecomputer/amd-flash.git", branch = "main" }
+amd-efs = { git = "ssh://git@github.com/oxidecomputer/amd-efs.git", rev = "e2a599e2f5b580ce1753c02b06ab019375ca3596", features = ["std", "serde", "schemars"] }
+amd-flash = { git = "ssh://git@github.com/oxidecomputer/amd-flash.git", rev = "90207243874f18cfc8b9fc1fd8f030dca4509458" }
 goblin = { version = "0.4", features = ["elf64", "endian_fd"] }
 #serde = { version = "1.0", default-features = false, features = ["derive"] }
 serde_json = "1.0.78"
 structopt = "0.3"
 amd-host-image-builder-config = { path = "amd-host-image-builder-config" }
 json5 = "0.4.1"
+static_assertions = "1.1.0"
 
 [dev-dependencies]
 valico = "2"
@@ -23,7 +24,7 @@ pathsep="0.1.1"
 
 [build-dependencies]
 amd-apcb = { git = "ssh://git@github.com/oxidecomputer/amd-apcb.git", rev = "70170e08f6d39af5a67de139832718940e628dfe", features = ["serde", "schemars"] }
-amd-efs = { git = "ssh://git@github.com/oxidecomputer/amd-efs.git", rev = "c6fefb9797d992fb9c6f757c2f44c720bf6cad95", features = ["std", "serde", "schemars"] }
+amd-efs = { git = "ssh://git@github.com/oxidecomputer/amd-efs.git", rev = "e2a599e2f5b580ce1753c02b06ab019375ca3596", features = ["std", "serde", "schemars"] }
 amd-host-image-builder-config = { path = "amd-host-image-builder-config" }
 schemars = "0.8.8"
 serde_json = "1.0.78"

--- a/Makefile
+++ b/Makefile
@@ -3,7 +3,7 @@ all: milan-ethanol-x rome-ethanol-x milan-gimlet-b
 .PHONY: all clean tests
 .PHONY: FRC
 
-SOURCES = amd-host-image-builder-config/src/lib.rs src/hole.rs src/main.rs src/static_config.rs
+SOURCES = amd-host-image-builder-config/src/lib.rs src/hole.rs src/main.rs src/static_config.rs Cargo.toml amd-host-image-builder-config/Cargo.toml Cargo.lock
 
 CARGO = cargo
 

--- a/amd-host-image-builder-config/Cargo.toml
+++ b/amd-host-image-builder-config/Cargo.toml
@@ -7,7 +7,7 @@ edition = "2018"
 
 [dependencies]
 amd-apcb = { git = "ssh://git@github.com/oxidecomputer/amd-apcb.git", rev = "70170e08f6d39af5a67de139832718940e628dfe", features = ["serde", "schemars"] }
-amd-efs = { git = "ssh://git@github.com/oxidecomputer/amd-efs.git", rev = "c6fefb9797d992fb9c6f757c2f44c720bf6cad95", features = ["std", "serde", "schemars"] }
-amd-flash = { git = "ssh://git@github.com/oxidecomputer/amd-flash.git", branch = "main" }
+amd-efs = { git = "ssh://git@github.com/oxidecomputer/amd-efs.git", rev = "e2a599e2f5b580ce1753c02b06ab019375ca3596", features = ["std", "serde", "schemars"] }
+amd-flash = { git = "ssh://git@github.com/oxidecomputer/amd-flash.git", rev = "90207243874f18cfc8b9fc1fd8f030dca4509458" }
 schemars = "0.8.8"
 serde = { version = "1.0", default-features = false, features = ["derive"] }

--- a/amd-host-image-builder-config/src/lib.rs
+++ b/amd-host-image-builder-config/src/lib.rs
@@ -36,6 +36,7 @@ pub type Result<T> = core::result::Result<T, Error>;
 
 #[derive(serde::Serialize, serde::Deserialize, schemars::JsonSchema)]
 #[serde(deny_unknown_fields)]
+#[derive(Debug)]
 pub struct SerdePspDirectoryEntryBlob {
 	#[serde(default)]
 	pub flash_location: Option<Location>,
@@ -72,7 +73,6 @@ pub struct SerdePspDirectoryEntry {
 	pub attrs: SerdePspDirectoryEntryAttrs,
 
 	#[serde(flatten)]
-	//#[serde(default)]
 	pub blob: Option<SerdePspDirectoryEntryBlob>,
 }
 
@@ -103,7 +103,8 @@ impl TryFromSerdeDirectoryEntryWithContext<SerdePspDirectoryEntry>
 			}),
 		)?
 		.with_sub_program(target.attrs.sub_program)
-		.with_rom_id(target.attrs.rom_id))
+		.with_rom_id(target.attrs.rom_id)
+		.build())
 	}
 }
 
@@ -167,7 +168,6 @@ pub struct SerdeBhdDirectoryEntry {
 	pub attrs: SerdeBhdDirectoryEntryAttrs,
 
 	#[serde(flatten)]
-	#[serde(default)]
 	pub blob: Option<SerdeBhdDirectoryEntryBlob>,
 }
 
@@ -197,7 +197,8 @@ impl TryFromSerdeDirectoryEntryWithContext<SerdeBhdDirectoryEntry>
 		.with_compressed(target.attrs.compressed)
 		.with_instance(target.attrs.instance)
 		.with_sub_program(target.attrs.sub_program)
-		.with_rom_id(target.attrs.rom_id))
+		.with_rom_id(target.attrs.rom_id)
+		.build())
 	}
 }
 

--- a/src/static_config.rs
+++ b/src/static_config.rs
@@ -5,11 +5,8 @@ pub(crate) const IMAGE_SIZE: u32 = 32 * 1024 * 1024;
 
 /* Coarse-grained flash locations (in Byte) */
 
-pub(crate) const PSP_BEGINNING: Location = 0x12_0000;
-pub(crate) const PSP_END: Location = 0x12_0000 + 0x12_0000;
-
-pub(crate) const BHD_BEGINNING: Location = 0x24_0000;
-pub(crate) const BHD_END: Location = 0x24_0000 + 0xA_0000;
+pub(crate) const PAYLOAD_BEGINNING: Location = 0x1_0000;
+pub(crate) const PAYLOAD_END: Location = RESET_IMAGE_BEGINNING;
 
 pub(crate) const RESET_IMAGE_BEGINNING: Location = 0x100_0000;
 pub(crate) const RESET_IMAGE_END: Location = 0x200_0000;


### PR DESCRIPTION
Fixes <https://github.com/oxidecomputer/amd-host-image-builder/issues/88>.