### PR TITLE
Standardize rustfmt.toml config

### DIFF
--- a/build.rs
+++ b/build.rs
@@ -8,29 +8,29 @@ use std::fs;
 use std::path::Path;
 
 pub fn generate_config_json_schema(outdir: &OsString) {
-	let settings = SchemaSettings::default().with(|s| {
-		// Work around schemars issue #62.
-		// Downside: This makes the schema bigger by an order
-		// of magnitude.
-		s.inline_subschemas = true
-	});
-	let gen = settings.into_generator();
-	let schema = gen.into_root_schema_for::<SerdeConfig>();
+    let settings = SchemaSettings::default().with(|s| {
+        // Work around schemars issue #62.
+        // Downside: This makes the schema bigger by an order
+        // of magnitude.
+        s.inline_subschemas = true
+    });
+    let gen = settings.into_generator();
+    let schema = gen.into_root_schema_for::<SerdeConfig>();
 
-	let schema_file = Path::new(outdir).join("efs.schema.json");
-	fs::write(schema_file, serde_json::to_string_pretty(&schema).unwrap())
-		.unwrap();
+    let schema_file = Path::new(outdir).join("efs.schema.json");
+    fs::write(schema_file, serde_json::to_string_pretty(&schema).unwrap())
+        .unwrap();
 }
 
 fn main() {
-	// OUT_DIR is set by Cargo and it's where any additional build artifacts
-	// are written.
-	let out_dir = match env::var_os("OUT_DIR") {
-		Some(out_dir) => out_dir,
-		None => {
-			eprintln!("OUT_DIR environment variable not defined.");
-			process::exit(1);
-		}
-	};
-	generate_config_json_schema(&out_dir);
+    // OUT_DIR is set by Cargo and it's where any additional build artifacts
+    // are written.
+    let out_dir = match env::var_os("OUT_DIR") {
+        Some(out_dir) => out_dir,
+        None => {
+            eprintln!("OUT_DIR environment variable not defined.");
+            process::exit(1);
+        }
+    };
+    generate_config_json_schema(&out_dir);
 }

--- a/rustfmt.toml
+++ b/rustfmt.toml
@@ -1,8 +1,4 @@
+edition = "2021"
 max_width = 80
-hard_tabs = true
-tab_spaces = 8
-spaces_around_ranges = true
-binop_separator = "Back"
+use_small_heuristics = "Max"
 newline_style = "Unix"
-#error_on_line_overflow = true
-error_on_unformatted = true

--- a/src/hole.rs
+++ b/src/hole.rs
@@ -2,25 +2,25 @@ use std::cmp::min;
 use std::io::Read;
 
 pub struct Hole {
-	cursor: usize, // amount remaining
+    cursor: usize, // amount remaining
 }
 
 impl Hole {
-	pub fn new(sz: usize) -> Self {
-		Self { cursor: sz }
-	}
+    pub fn new(sz: usize) -> Self {
+        Self { cursor: sz }
+    }
 }
 
 impl Read for Hole {
-	fn read(&mut self, buf: &mut [u8]) -> std::io::Result<usize> {
-		if self.cursor == 0 {
-			return Ok(0);
-		}
-		let l = min(buf.len(), self.cursor);
-		for slot in &mut buf[0 .. l] {
-			*slot = 0;
-		}
-		self.cursor -= l;
-		Ok(l)
-	}
+    fn read(&mut self, buf: &mut [u8]) -> std::io::Result<usize> {
+        if self.cursor == 0 {
+            return Ok(0);
+        }
+        let l = min(buf.len(), self.cursor);
+        for slot in &mut buf[0..l] {
+            *slot = 0;
+        }
+        self.cursor -= l;
+        Ok(l)
+    }
 }

--- a/src/main.rs
+++ b/src/main.rs
@@ -1,12 +1,12 @@
 use amd_efs::{
-	AddressMode, BhdDirectory, BhdDirectoryEntry, BhdDirectoryEntryType,
-	DirectoryEntry, Efs, PspDirectory, PspDirectoryEntry,
-	PspDirectoryEntryType, ValueOrLocation,
+    AddressMode, BhdDirectory, BhdDirectoryEntry, BhdDirectoryEntryType,
+    DirectoryEntry, Efs, PspDirectory, PspDirectoryEntry,
+    PspDirectoryEntryType, ValueOrLocation,
 };
 use amd_host_image_builder_config::{
-	Error, Result, SerdeBhdDirectoryVariant, SerdeBhdSource,
-	SerdePspDirectoryVariant, SerdePspEntrySource,
-	TryFromSerdeDirectoryEntryWithContext,
+    Error, Result, SerdeBhdDirectoryVariant, SerdeBhdSource,
+    SerdePspDirectoryVariant, SerdePspEntrySource,
+    TryFromSerdeDirectoryEntryWithContext,
 };
 use core::cell::RefCell;
 use core::convert::TryFrom;
@@ -27,142 +27,143 @@ use structopt::StructOpt;
 mod static_config;
 
 use amd_flash::{
-	ErasableLocation, ErasableRange, FlashAlign, FlashRead, FlashWrite, Location,
+    ErasableLocation, ErasableRange, FlashAlign, FlashRead, FlashWrite,
+    Location,
 };
 use amd_host_image_builder_config::SerdeConfig;
 
 #[test]
 fn test_bitfield_serde() {
-	let config = r#"{
+    let config = r#"{
 	"max_size": 2,
 	"base_address": 3,
 	"address_mode": "PhysicalAddress"
 }"#;
-	use amd_efs::DirectoryAdditionalInfo;
-	let result: DirectoryAdditionalInfo = json5::from_str(config).unwrap();
-	assert_eq!(result.address_mode(), AddressMode::PhysicalAddress);
+    use amd_efs::DirectoryAdditionalInfo;
+    let result: DirectoryAdditionalInfo = json5::from_str(config).unwrap();
+    assert_eq!(result.address_mode(), AddressMode::PhysicalAddress);
 }
 
 mod hole;
 use hole::Hole;
 
 struct FlashImage {
-	file: RefCell<File>,
-	filename: PathBuf,
-	erasable_block_size: usize,
-	buffer: RefCell<Vec<u8>>,
+    file: RefCell<File>,
+    filename: PathBuf,
+    erasable_block_size: usize,
+    buffer: RefCell<Vec<u8>>,
 }
 
 impl FlashRead for FlashImage {
-	fn read_exact(
-		&self,
-		location: Location,
-		buffer: &mut [u8],
-	) -> amd_flash::Result<()> {
-		let mut file = self.file.borrow_mut();
-		file.seek(SeekFrom::Start(location.into())).map_err(|e| {
-			eprintln!(
-				"Error seeking in flash image {:?}: {:?}",
-				self.filename, e
-			);
-			amd_flash::Error::Io
-		})?;
-		file.read_exact(buffer).map_err(|e| {
-			eprintln!(
-				"Error reading from flash image {:?}: {:?}",
-				self.filename, e
-			);
-			amd_flash::Error::Io
-		})
-	}
+    fn read_exact(
+        &self,
+        location: Location,
+        buffer: &mut [u8],
+    ) -> amd_flash::Result<()> {
+        let mut file = self.file.borrow_mut();
+        file.seek(SeekFrom::Start(location.into())).map_err(|e| {
+            eprintln!(
+                "Error seeking in flash image {:?}: {:?}",
+                self.filename, e
+            );
+            amd_flash::Error::Io
+        })?;
+        file.read_exact(buffer).map_err(|e| {
+            eprintln!(
+                "Error reading from flash image {:?}: {:?}",
+                self.filename, e
+            );
+            amd_flash::Error::Io
+        })
+    }
 }
 
 impl FlashAlign for FlashImage {
-	fn erasable_block_size(&self) -> usize {
-		self.erasable_block_size
-	}
+    fn erasable_block_size(&self) -> usize {
+        self.erasable_block_size
+    }
 }
 
 impl FlashWrite for FlashImage {
-	fn erase_block(
-		&self,
-		location: ErasableLocation,
-	) -> amd_flash::Result<()> {
-		let erasable_block_size = self.erasable_block_size();
-		let location = self.location(location)?;
-		let mut file = self.file.borrow_mut();
-		match file.seek(SeekFrom::Start(location.into())) {
-			Ok(_) => {}
-			Err(e) => {
-				eprintln!("Error seeking in flash image {:?}: {:?}", self.filename, e);
-				return Err(amd_flash::Error::Io);
-			}
-		}
-		let mut buffer = self.buffer.borrow_mut();
-		buffer.fill(0xff);
-		match file.write(&buffer[..]) {
-			Ok(size) => {
-				assert!(size == erasable_block_size);
-				Ok(())
-			}
-			Err(e) => {
-				eprintln!("Error writing to flash image {:?}: {:?}", self.filename, e);
-				return Err(amd_flash::Error::Io);
-			}
-		}
-	}
-	fn erase_and_write_block(
-		&self,
-		location: ErasableLocation,
-		buffer: &[u8],
-	) -> amd_flash::Result<()> {
-		let erasable_block_size = self.erasable_block_size;
-		if buffer.len() > erasable_block_size {
-			return Err(amd_flash::Error::Programmer);
-		}
-		let location = self.location(location)?;
-		let mut file = self.file.borrow_mut();
-		file.seek(SeekFrom::Start(location.into())).map_err(|e| {
-			eprintln!(
-				"Error seeking in flash image {:?}: {:?}",
-				self.filename, e
-			);
-			amd_flash::Error::Io
-		})?;
-		let mut xbuffer = self.buffer.borrow_mut();
-		xbuffer.fill(0xff);
-		xbuffer[.. buffer.len()].copy_from_slice(buffer);
-		match file.write(&xbuffer) {
-			Ok(size) => {
-				assert!(size == xbuffer.len());
-				Ok(())
-			}
-			Err(e) => {
-				eprintln!("Error writing to flash image {:?}: {:?}", self.filename, e);
-				return Err(amd_flash::Error::Io);
-			}
-		}
-	}
+    fn erase_block(&self, location: ErasableLocation) -> amd_flash::Result<()> {
+        let erasable_block_size = self.erasable_block_size();
+        let location = self.location(location)?;
+        let mut file = self.file.borrow_mut();
+        match file.seek(SeekFrom::Start(location.into())) {
+            Ok(_) => {}
+            Err(e) => {
+                eprintln!(
+                    "Error seeking in flash image {:?}: {:?}",
+                    self.filename, e
+                );
+                return Err(amd_flash::Error::Io);
+            }
+        }
+        let mut buffer = self.buffer.borrow_mut();
+        buffer.fill(0xff);
+        match file.write(&buffer[..]) {
+            Ok(size) => {
+                assert!(size == erasable_block_size);
+                Ok(())
+            }
+            Err(e) => {
+                eprintln!(
+                    "Error writing to flash image {:?}: {:?}",
+                    self.filename, e
+                );
+                return Err(amd_flash::Error::Io);
+            }
+        }
+    }
+    fn erase_and_write_block(
+        &self,
+        location: ErasableLocation,
+        buffer: &[u8],
+    ) -> amd_flash::Result<()> {
+        let erasable_block_size = self.erasable_block_size;
+        if buffer.len() > erasable_block_size {
+            return Err(amd_flash::Error::Programmer);
+        }
+        let location = self.location(location)?;
+        let mut file = self.file.borrow_mut();
+        file.seek(SeekFrom::Start(location.into())).map_err(|e| {
+            eprintln!(
+                "Error seeking in flash image {:?}: {:?}",
+                self.filename, e
+            );
+            amd_flash::Error::Io
+        })?;
+        let mut xbuffer = self.buffer.borrow_mut();
+        xbuffer.fill(0xff);
+        xbuffer[..buffer.len()].copy_from_slice(buffer);
+        match file.write(&xbuffer) {
+            Ok(size) => {
+                assert!(size == xbuffer.len());
+                Ok(())
+            }
+            Err(e) => {
+                eprintln!(
+                    "Error writing to flash image {:?}: {:?}",
+                    self.filename, e
+                );
+                return Err(amd_flash::Error::Io);
+            }
+        }
+    }
 }
 
 impl FlashImage {
-	fn new(
-		file: File,
-		filename: &Path,
-		erasable_block_size: usize,
-	) -> Self {
-		assert!(erasable_block_size.is_power_of_two());
-		Self {
-			file: RefCell::new(file),
-			filename: filename.to_path_buf(),
-			erasable_block_size,
-			buffer: RefCell::new(
-				std::iter::repeat(0xff)
-					.take(erasable_block_size)
-					.collect(),
-			),
-		}
-	}
+    fn new(file: File, filename: &Path, erasable_block_size: usize) -> Self {
+        assert!(erasable_block_size.is_power_of_two());
+        Self {
+            file: RefCell::new(file),
+            filename: filename.to_path_buf(),
+            erasable_block_size,
+            buffer: RefCell::new(
+                std::iter::repeat(0xff).take(erasable_block_size).collect(),
+            ),
+        }
+    }
 }
 
 type AlignedLocation = ErasableLocation;
@@ -172,37 +173,36 @@ type AlignedLocation = ErasableLocation;
 /// If file is too big, error out.
 /// Otherwise, return the size to use for the entry payload.
 fn size_file(
-	source_filename: &Path,
-	target_size: Option<u32>,
+    source_filename: &Path,
+    target_size: Option<u32>,
 ) -> amd_efs::Result<(File, u32)> {
-	let file = match File::open(source_filename) {
-		Ok(f) => f,
-		Err(e) => {
-			panic!(
-				"Could not open file {:?}: {}",
-				source_filename, e
-			);
-		}
-	};
-	let filesize: usize = file
-		.metadata()
-		.map_err(|_| amd_efs::Error::Io(amd_flash::Error::Io))?
-		.len()
-		.try_into()
-		.map_err(|_| amd_efs::Error::Io(amd_flash::Error::Io))?;
-	match target_size {
-		Some(x) => {
-			if filesize > x as usize {
-				panic!("Configuration specifies slot size {} but contents {:?} have size {}. The contents do not fit.", x, source_filename, filesize);
-			} else {
-				Ok((file, x))
-			}
-		}
-		None => Ok((file,
-		            filesize
-		            	.try_into()
-		            	.map_err(|_| amd_efs::Error::DirectoryPayloadRangeCheck)?)),
-	}
+    let file = match File::open(source_filename) {
+        Ok(f) => f,
+        Err(e) => {
+            panic!("Could not open file {:?}: {}", source_filename, e);
+        }
+    };
+    let filesize: usize = file
+        .metadata()
+        .map_err(|_| amd_efs::Error::Io(amd_flash::Error::Io))?
+        .len()
+        .try_into()
+        .map_err(|_| amd_efs::Error::Io(amd_flash::Error::Io))?;
+    match target_size {
+        Some(x) => {
+            if filesize > x as usize {
+                panic!("Configuration specifies slot size {} but contents {:?} have size {}. The contents do not fit.", x, source_filename, filesize);
+            } else {
+                Ok((file, x))
+            }
+        }
+        None => Ok((
+            file,
+            filesize
+                .try_into()
+                .map_err(|_| amd_efs::Error::DirectoryPayloadRangeCheck)?,
+        )),
+    }
 }
 
 /// Reads the file named SOURCE_FILENAME, finds the version field in there (if any) and returns
@@ -210,544 +210,528 @@ fn size_file(
 /// In case of error (file can't be read, version field not found, ...),
 /// returns None.
 fn psp_file_version(source_filename: &Path) -> Option<u32> {
-	// Note: This does not work on Rome and neither do we know a useful
-	// ABL version there anyway. But the magic also doesn't match, so
-	// this will be fine.
-	let (file, _size) = size_file(source_filename, None).ok()?;
-	let mut source = BufReader::new(file);
-	let mut header: [u8; 0x100] = [0; 0x100];
-	if let Ok(_) = source.read_exact(&mut header) {
-		let magic = &header[0x10 .. 0x14];
-		if magic == *b"$PS1" {
-			let version_raw =
-				<[u8; 4]>::try_from(&header[0x60 .. 0x64])
-					.ok()?;
-			let version = u32::from_le_bytes(version_raw);
-			Some(version)
-		} else {
-			None
-		}
-	} else {
-		None
-	}
+    // Note: This does not work on Rome and neither do we know a useful
+    // ABL version there anyway. But the magic also doesn't match, so
+    // this will be fine.
+    let (file, _size) = size_file(source_filename, None).ok()?;
+    let mut source = BufReader::new(file);
+    let mut header: [u8; 0x100] = [0; 0x100];
+    if let Ok(_) = source.read_exact(&mut header) {
+        let magic = &header[0x10..0x14];
+        if magic == *b"$PS1" {
+            let version_raw = <[u8; 4]>::try_from(&header[0x60..0x64]).ok()?;
+            let version = u32::from_le_bytes(version_raw);
+            Some(version)
+        } else {
+            None
+        }
+    } else {
+        None
+    }
 }
 
 fn elf_symbol(
-	binary: &goblin::elf::Elf,
-	key: &str,
+    binary: &goblin::elf::Elf,
+    key: &str,
 ) -> Option<goblin::elf::Sym> {
-	for sym in &binary.syms {
-		let ix = sym.st_name;
-		if ix != 0 {
-			if &binary.strtab[sym.st_name] == key {
-				return Some(sym);
-			}
-		}
-	}
-	None
+    for sym in &binary.syms {
+        let ix = sym.st_name;
+        if ix != 0 {
+            if &binary.strtab[sym.st_name] == key {
+                return Some(sym);
+            }
+        }
+    }
+    None
 }
 
 fn bhd_directory_add_reset_image(
-	reset_image_filename: &Path,
+    reset_image_filename: &Path,
 ) -> Result<(BhdDirectoryEntry, Vec<u8>)> {
-	let buffer =
-		fs::read(reset_image_filename).map_err(|x| Error::Io(x))?;
-	let mut destination_origin: Option<u64> = None;
-	let mut iov = Box::new(std::io::empty()) as Box<dyn Read>;
-	let sz;
+    let buffer = fs::read(reset_image_filename).map_err(|x| Error::Io(x))?;
+    let mut destination_origin: Option<u64> = None;
+    let mut iov = Box::new(std::io::empty()) as Box<dyn Read>;
+    let sz;
 
-	match goblin::Object::parse(&buffer)
-		.map_err(|_| Error::IncompatibleExecutable)?
-	{
-		goblin::Object::Elf(binary) => {
-			let mut last_vaddr = 0u64;
-			let mut holesz = 0usize;
-			let mut totalsz = 0usize;
-			if binary.header.e_type != goblin::elf::header::ET_EXEC ||
-				binary.header.e_machine !=
-					goblin::elf::header::EM_X86_64 || binary
-				.header
-				.e_version <
-				goblin::elf::header::EV_CURRENT.into()
-			{
-				return Err(Error::IncompatibleExecutable);
-			}
-			for header in &binary.program_headers {
-				if header.p_type ==
-					goblin::elf::program_header::PT_LOAD
-				{
-					//eprintln!("PROG {:x?}", header);
-					if header.p_memsz == 0 {
-						continue;
-					}
-					if destination_origin == None {
-						// Note: File is sorted by p_vaddr.
-						destination_origin =
-							Some(header.p_vaddr);
-						last_vaddr = header.p_vaddr;
-					}
-					if header.p_vaddr < last_vaddr {
-						// According to ELF standard, this should not happen
-						return Err(Error::IncompatibleExecutable);
-					}
-					if header.p_filesz > header.p_memsz {
-						// According to ELF standard, this should not happen
-						return Err(Error::IncompatibleExecutable);
-					}
-					if header.p_paddr != header.p_vaddr {
-						return Err(Error::IncompatibleExecutable);
-					}
-					if header.p_filesz > 0 {
-						if header.p_vaddr > last_vaddr {
-							holesz += (header
-								.p_vaddr -
-								last_vaddr)
-								as usize;
-						}
-						if holesz > 0 {
-							//eprintln!("hole: {:x}", holesz);
-							iov = Box::new(iov.chain(Hole::new(holesz))) as Box<dyn Read>;
-							totalsz += holesz;
-							holesz = 0;
-						}
-						let chunk = &buffer[header
-							.p_offset
-							as usize ..
-							(header.p_offset +
-								header.p_filesz)
-								as usize];
-						//eprintln!("chunk: {:x} @ {:x}", header.p_filesz, header.p_offset);
-						iov = Box::new(iov.chain(chunk))
-							as Box<dyn Read>;
-						totalsz += header.p_filesz
-							as usize;
-						if header.p_memsz >
-							header.p_filesz
-						{
-							holesz += (header
-								.p_memsz -
-								header.p_filesz)
-								as usize;
-						}
-						last_vaddr = header.p_vaddr +
-							header.p_memsz;
-					}
-				}
-			}
-			// SYMBOL "_BL_SPACE" Sym { st_name: 5342, st_info: 0x0 LOCAL NOTYPE, st_other: 0 DEFAULT, st_shndx: 65521, st_value: 0x29000, st_size: 0 }
-			// The part of the program we copy into the flash image should be
-			// of the same size as the space allocated at loader build time.
-			let symsz = elf_symbol(&binary, "_BL_SPACE")
-				.ok_or(Error::IncompatibleExecutable)?
-				.st_value;
-			//eprintln!("_BL_SPACE: {:x?}", symsz);
-			if totalsz != symsz as usize {
-				return Err(Error::IncompatibleExecutable);
-			}
-			sz = totalsz;
+    match goblin::Object::parse(&buffer)
+        .map_err(|_| Error::IncompatibleExecutable)?
+    {
+        goblin::Object::Elf(binary) => {
+            let mut last_vaddr = 0u64;
+            let mut holesz = 0usize;
+            let mut totalsz = 0usize;
+            if binary.header.e_type != goblin::elf::header::ET_EXEC
+                || binary.header.e_machine != goblin::elf::header::EM_X86_64
+                || binary.header.e_version
+                    < goblin::elf::header::EV_CURRENT.into()
+            {
+                return Err(Error::IncompatibleExecutable);
+            }
+            for header in &binary.program_headers {
+                if header.p_type == goblin::elf::program_header::PT_LOAD {
+                    //eprintln!("PROG {:x?}", header);
+                    if header.p_memsz == 0 {
+                        continue;
+                    }
+                    if destination_origin == None {
+                        // Note: File is sorted by p_vaddr.
+                        destination_origin = Some(header.p_vaddr);
+                        last_vaddr = header.p_vaddr;
+                    }
+                    if header.p_vaddr < last_vaddr {
+                        // According to ELF standard, this should not happen
+                        return Err(Error::IncompatibleExecutable);
+                    }
+                    if header.p_filesz > header.p_memsz {
+                        // According to ELF standard, this should not happen
+                        return Err(Error::IncompatibleExecutable);
+                    }
+                    if header.p_paddr != header.p_vaddr {
+                        return Err(Error::IncompatibleExecutable);
+                    }
+                    if header.p_filesz > 0 {
+                        if header.p_vaddr > last_vaddr {
+                            holesz += (header.p_vaddr - last_vaddr) as usize;
+                        }
+                        if holesz > 0 {
+                            //eprintln!("hole: {:x}", holesz);
+                            iov = Box::new(iov.chain(Hole::new(holesz)))
+                                as Box<dyn Read>;
+                            totalsz += holesz;
+                            holesz = 0;
+                        }
+                        let chunk = &buffer[header.p_offset as usize
+                            ..(header.p_offset + header.p_filesz) as usize];
+                        //eprintln!("chunk: {:x} @ {:x}", header.p_filesz, header.p_offset);
+                        iov = Box::new(iov.chain(chunk)) as Box<dyn Read>;
+                        totalsz += header.p_filesz as usize;
+                        if header.p_memsz > header.p_filesz {
+                            holesz +=
+                                (header.p_memsz - header.p_filesz) as usize;
+                        }
+                        last_vaddr = header.p_vaddr + header.p_memsz;
+                    }
+                }
+            }
+            // SYMBOL "_BL_SPACE" Sym { st_name: 5342, st_info: 0x0 LOCAL NOTYPE, st_other: 0 DEFAULT, st_shndx: 65521, st_value: 0x29000, st_size: 0 }
+            // The part of the program we copy into the flash image should be
+            // of the same size as the space allocated at loader build time.
+            let symsz = elf_symbol(&binary, "_BL_SPACE")
+                .ok_or(Error::IncompatibleExecutable)?
+                .st_value;
+            //eprintln!("_BL_SPACE: {:x?}", symsz);
+            if totalsz != symsz as usize {
+                return Err(Error::IncompatibleExecutable);
+            }
+            sz = totalsz;
 
-			// These symbols have been embedded into the loader to serve as
-			// checks in this exact application.
-			let sloader = elf_symbol(&binary, "__sloader")
-				.ok_or(Error::IncompatibleExecutable)?
-				.st_value;
-			//eprintln!("__sloader: {:x?}", sloader);
-			if sloader !=
-				destination_origin.ok_or(
-					Error::IncompatibleExecutable,
-				)? {
-				return Err(Error::IncompatibleExecutable);
-			}
+            // These symbols have been embedded into the loader to serve as
+            // checks in this exact application.
+            let sloader = elf_symbol(&binary, "__sloader")
+                .ok_or(Error::IncompatibleExecutable)?
+                .st_value;
+            //eprintln!("__sloader: {:x?}", sloader);
+            if sloader
+                != destination_origin.ok_or(Error::IncompatibleExecutable)?
+            {
+                return Err(Error::IncompatibleExecutable);
+            }
 
-			let eloader = elf_symbol(&binary, "__eloader")
-				.ok_or(Error::IncompatibleExecutable)?
-				.st_value;
-			//eprintln!("__eloader: {:x?}", eloader);
-			if eloader != last_vaddr {
-				return Err(Error::IncompatibleExecutable);
-			}
+            let eloader = elf_symbol(&binary, "__eloader")
+                .ok_or(Error::IncompatibleExecutable)?
+                .st_value;
+            //eprintln!("__eloader: {:x?}", eloader);
+            if eloader != last_vaddr {
+                return Err(Error::IncompatibleExecutable);
+            }
 
-			// The entry point (reset vector) must be 0x10 bytes below the
-			// end of a (real-mode) segment--and that segment must begin at the end
-			// of the loaded program.  See AMD pub 55758 sec. 4.3 item 4.
-			if binary.header.e_entry !=
-				last_vaddr.checked_sub(0x10).ok_or(
-					Error::IncompatibleExecutable,
-				)? {
-				return Err(Error::IncompatibleExecutable);
-			}
-			if last_vaddr & 0xffff != 0 {
-				return Err(Error::IncompatibleExecutable);
-			}
-		}
-		_ => {
-			destination_origin = Some(0x8000_0000u64
-				.checked_sub(buffer.len() as u64)
-				.ok_or(Error::ImageTooBig)?);
-			iov = Box::new(&buffer.as_slice()[..]) as Box<dyn Read>;
-			sz = buffer.len();
-		}
-	}
+            // The entry point (reset vector) must be 0x10 bytes below the
+            // end of a (real-mode) segment--and that segment must begin at the end
+            // of the loaded program.  See AMD pub 55758 sec. 4.3 item 4.
+            if binary.header.e_entry
+                != last_vaddr
+                    .checked_sub(0x10)
+                    .ok_or(Error::IncompatibleExecutable)?
+            {
+                return Err(Error::IncompatibleExecutable);
+            }
+            if last_vaddr & 0xffff != 0 {
+                return Err(Error::IncompatibleExecutable);
+            }
+        }
+        _ => {
+            destination_origin = Some(
+                0x8000_0000u64
+                    .checked_sub(buffer.len() as u64)
+                    .ok_or(Error::ImageTooBig)?,
+            );
+            iov = Box::new(&buffer.as_slice()[..]) as Box<dyn Read>;
+            sz = buffer.len();
+        }
+    }
 
-	if destination_origin == None {
-		eprintln!("Warning: No destination in RAM specified for Reset image.");
-	}
+    if destination_origin == None {
+        eprintln!("Warning: No destination in RAM specified for Reset image.");
+    }
 
-	let entry = BhdDirectoryEntry::new_payload(
-		AddressMode::EfsRelativeOffset,
-		BhdDirectoryEntryType::Bios,
-		Some(sz
-		         .try_into()
-		         .map_err(|_| amd_efs::Error::DirectoryPayloadRangeCheck)?),
-		None,
-		destination_origin,
-	)?
-	.with_reset_image(true)
-	.with_copy_image(true)
-	.build();
-	// Write write_all
-	let mut result = Vec::<u8>::new();
-	std::io::copy(&mut iov, &mut result).unwrap();
-	Ok((entry, result))
+    let entry = BhdDirectoryEntry::new_payload(
+        AddressMode::EfsRelativeOffset,
+        BhdDirectoryEntryType::Bios,
+        Some(
+            sz.try_into()
+                .map_err(|_| amd_efs::Error::DirectoryPayloadRangeCheck)?,
+        ),
+        None,
+        destination_origin,
+    )?
+    .with_reset_image(true)
+    .with_copy_image(true)
+    .build();
+    // Write write_all
+    let mut result = Vec::<u8>::new();
+    std::io::copy(&mut iov, &mut result).unwrap();
+    Ok((entry, result))
 }
 
 #[derive(Debug, StructOpt)]
 #[structopt(
-	name = "amd-host-image-builder",
-	about = "Build host flash image for AMD Zen CPUs."
+    name = "amd-host-image-builder",
+    about = "Build host flash image for AMD Zen CPUs."
 )]
 struct Opts {
-	#[structopt(short = "o", long = "output-file", parse(from_os_str))]
-	output_filename: PathBuf,
+    #[structopt(short = "o", long = "output-file", parse(from_os_str))]
+    output_filename: PathBuf,
 
-	#[structopt(short = "r", long = "reset-image", parse(from_os_str))]
-	reset_image_filename: PathBuf,
+    #[structopt(short = "r", long = "reset-image", parse(from_os_str))]
+    reset_image_filename: PathBuf,
 
-	#[structopt(short = "c", long = "config", parse(from_os_str))]
-	efs_configuration_filename: PathBuf,
+    #[structopt(short = "c", long = "config", parse(from_os_str))]
+    efs_configuration_filename: PathBuf,
 
-	#[structopt(short = "B", long = "blobdir", parse(from_os_str))]
-	blobdirs: Vec<PathBuf>,
+    #[structopt(short = "B", long = "blobdir", parse(from_os_str))]
+    blobdirs: Vec<PathBuf>,
 
-	#[structopt(short = "v", long = "verbose")]
-	verbose: bool,
+    #[structopt(short = "v", long = "verbose")]
+    verbose: bool,
 }
 
 fn save_psp_directory<T: FlashRead + FlashWrite>(
-	psp_raw_entries: &mut Vec<(
-		PspDirectoryEntry,
-		Option<Location>,
-		Option<Vec<u8>>,
-	)>,
-	psp_directory_address_mode: AddressMode,
-	storage: &FlashImage,
-	mut payload_range: ErasableRange,
-	efs: &mut Efs<T>,
+    psp_raw_entries: &mut Vec<(
+        PspDirectoryEntry,
+        Option<Location>,
+        Option<Vec<u8>>,
+    )>,
+    psp_directory_address_mode: AddressMode,
+    storage: &FlashImage,
+    mut payload_range: ErasableRange,
+    efs: &mut Efs<T>,
 ) -> std::io::Result<ErasableRange> {
-	let opts = Opts::from_args();
-	let filename = &opts.output_filename;
-	let efs_to_io_error = |e| {
-		std::io::Error::new(
-			std::io::ErrorKind::Other,
-			format!("EFS error: {:?} in file {:?}", e, filename),
-		)
-	};
+    let opts = Opts::from_args();
+    let filename = &opts.output_filename;
+    let efs_to_io_error = |e| {
+        std::io::Error::new(
+            std::io::ErrorKind::Other,
+            format!("EFS error: {:?} in file {:?}", e, filename),
+        )
+    };
 
-	let first_payload_range_beginning = payload_range.beginning;
+    let first_payload_range_beginning = payload_range.beginning;
 
-	// Here we know how big the directory is gonna be.
+    // Here we know how big the directory is gonna be.
 
-	let psp_directory_size = PspDirectory::minimal_directory_size(
-		u32::try_from(psp_raw_entries.len())
-			.map_err(|_| amd_efs::Error::DirectoryRangeCheck)
-			.map_err(efs_to_io_error)?,
-	)
-		.map_err(efs_to_io_error)?;
+    let psp_directory_size = PspDirectory::minimal_directory_size(
+        u32::try_from(psp_raw_entries.len())
+            .map_err(|_| amd_efs::Error::DirectoryRangeCheck)
+            .map_err(efs_to_io_error)?,
+    )
+    .map_err(efs_to_io_error)?;
 
-	// Traverse psp_raw_entries and update SOURCE accordingly
-	// using payload_range for guidance
+    // Traverse psp_raw_entries and update SOURCE accordingly
+    // using payload_range for guidance
 
-	for (entry, source_override, blob_body) in psp_raw_entries.iter_mut() {
-		if let Some(blob_body) = blob_body {
-			let source = if let Some(source_override) =
-				source_override
-			{
-				assert!(false); // other case is untested
-				*source_override
-			} else {
-				let (destination, rest) = payload_range
-					.split_at_least(blob_body.len());
-				payload_range = rest;
-				Location::from(destination.beginning)
-			};
-			// TODO set_size maybe
-			entry.set_source(
-				AddressMode::DirectoryRelativeOffset,
-				ValueOrLocation::EfsRelativeOffset(source),
-			)
-				.map_err(efs_to_io_error)?;
-		}
-	}
+    for (entry, source_override, blob_body) in psp_raw_entries.iter_mut() {
+        if let Some(blob_body) = blob_body {
+            let source = if let Some(source_override) = source_override {
+                assert!(false); // other case is untested
+                *source_override
+            } else {
+                let (destination, rest) =
+                    payload_range.split_at_least(blob_body.len());
+                payload_range = rest;
+                Location::from(destination.beginning)
+            };
+            // TODO set_size maybe
+            entry
+                .set_source(
+                    AddressMode::DirectoryRelativeOffset,
+                    ValueOrLocation::EfsRelativeOffset(source),
+                )
+                .map_err(efs_to_io_error)?;
+        }
+    }
 
-	let psp_entries = psp_raw_entries
-		.iter()
-		.map(|(raw_entry, _, _)| raw_entry.clone())
-		.collect::<Vec<PspDirectoryEntry>>();
-	let (psp_directory_range, payload_range) = payload_range.split_at_least(psp_directory_size as usize);
-	let psp_directory_beginning = psp_directory_range.beginning;
-	let psp_directory_end = psp_directory_range.end;
-	let mut psp_directory = efs
-		.create_psp_directory(
-			psp_directory_beginning,
-			psp_directory_end,
-			psp_directory_address_mode,
-			Some(first_payload_range_beginning),
-			&psp_entries,
-		)
-		.map_err(efs_to_io_error)?;
+    let psp_entries = psp_raw_entries
+        .iter()
+        .map(|(raw_entry, _, _)| raw_entry.clone())
+        .collect::<Vec<PspDirectoryEntry>>();
+    let (psp_directory_range, payload_range) =
+        payload_range.split_at_least(psp_directory_size as usize);
+    let psp_directory_beginning = psp_directory_range.beginning;
+    let psp_directory_end = psp_directory_range.end;
+    let mut psp_directory = efs
+        .create_psp_directory(
+            psp_directory_beginning,
+            psp_directory_end,
+            psp_directory_address_mode,
+            Some(first_payload_range_beginning),
+            &psp_entries,
+        )
+        .map_err(efs_to_io_error)?;
 
-	psp_directory
-		.save(storage, psp_directory_range, first_payload_range_beginning)
-		.map_err(efs_to_io_error)?;
-	Ok(payload_range)
+    psp_directory
+        .save(storage, psp_directory_range, first_payload_range_beginning)
+        .map_err(efs_to_io_error)?;
+    Ok(payload_range)
 }
 
 fn save_bhd_directory<T: FlashRead + FlashWrite>(
-	bhd_raw_entries: &mut Vec<(
-		BhdDirectoryEntry,
-		Option<Location>,
-		Option<Vec<u8>>,
-	)>,
-	bhd_directory_address_mode: AddressMode,
-	storage: &FlashImage,
-	mut payload_range: ErasableRange,
-	efs: &mut Efs<T>,
+    bhd_raw_entries: &mut Vec<(
+        BhdDirectoryEntry,
+        Option<Location>,
+        Option<Vec<u8>>,
+    )>,
+    bhd_directory_address_mode: AddressMode,
+    storage: &FlashImage,
+    mut payload_range: ErasableRange,
+    efs: &mut Efs<T>,
 ) -> std::io::Result<ErasableRange> {
-	let opts = Opts::from_args();
-	let filename = &opts.output_filename;
-	let efs_to_io_error = |e| {
-		std::io::Error::new(
-			std::io::ErrorKind::Other,
-			format!("EFS error: {:?} in file {:?}", e, filename),
-		)
-	};
+    let opts = Opts::from_args();
+    let filename = &opts.output_filename;
+    let efs_to_io_error = |e| {
+        std::io::Error::new(
+            std::io::ErrorKind::Other,
+            format!("EFS error: {:?} in file {:?}", e, filename),
+        )
+    };
 
-	let first_payload_range_beginning = payload_range.beginning;
+    let first_payload_range_beginning = payload_range.beginning;
 
-	// Here we know how big the directory is gonna be.
+    // Here we know how big the directory is gonna be.
 
-	let bhd_directory_size = BhdDirectory::minimal_directory_size(
-		u32::try_from(bhd_raw_entries.len())
-			.map_err(|_| amd_efs::Error::Misaligned)
-			.map_err(efs_to_io_error)?,
-	)
-		.map_err(efs_to_io_error)?;
+    let bhd_directory_size = BhdDirectory::minimal_directory_size(
+        u32::try_from(bhd_raw_entries.len())
+            .map_err(|_| amd_efs::Error::Misaligned)
+            .map_err(efs_to_io_error)?,
+    )
+    .map_err(efs_to_io_error)?;
 
-	// Traverse bhd_raw_entries and update SOURCE accordingly
-	// using payload_range for guidance
+    // Traverse bhd_raw_entries and update SOURCE accordingly
+    // using payload_range for guidance
 
-	for (entry, source_override, blob_body) in bhd_raw_entries.iter_mut() {
-		if let Some(blob_body) = blob_body {
-			let source = if let Some(source_override) =
-				source_override
-			{
-				*source_override
-			} else {
-				let (destination, rest) = payload_range
-					.split_at_least(blob_body.len());
-				payload_range = rest;
-				Location::from(destination.beginning)
-			};
-			// Required because of BhdDirectoryEntry::new_payload() for reset image.
-			entry.set_size(Some(blob_body
-				.len()
-				.try_into()
-				.map_err(|_| amd_efs::Error::DirectoryPayloadRangeCheck)
-				.map_err(efs_to_io_error)?));
-			entry.set_source(
-				AddressMode::DirectoryRelativeOffset,
-				ValueOrLocation::EfsRelativeOffset(source),
-			)
-				.map_err(efs_to_io_error)?;
-		}
-	}
+    for (entry, source_override, blob_body) in bhd_raw_entries.iter_mut() {
+        if let Some(blob_body) = blob_body {
+            let source = if let Some(source_override) = source_override {
+                *source_override
+            } else {
+                let (destination, rest) =
+                    payload_range.split_at_least(blob_body.len());
+                payload_range = rest;
+                Location::from(destination.beginning)
+            };
+            // Required because of BhdDirectoryEntry::new_payload() for reset image.
+            entry.set_size(Some(
+                blob_body
+                    .len()
+                    .try_into()
+                    .map_err(|_| amd_efs::Error::DirectoryPayloadRangeCheck)
+                    .map_err(efs_to_io_error)?,
+            ));
+            entry
+                .set_source(
+                    AddressMode::DirectoryRelativeOffset,
+                    ValueOrLocation::EfsRelativeOffset(source),
+                )
+                .map_err(efs_to_io_error)?;
+        }
+    }
 
-	let bhd_entries = bhd_raw_entries
-		.iter()
-		.map(|(raw_entry, _, _)| raw_entry.clone())
-		.collect::<Vec<BhdDirectoryEntry>>();
-        let (bhd_directory_range, payload_range) = payload_range.split_at_least(bhd_directory_size as usize);
-	let bhd_directory_beginning = bhd_directory_range.beginning;
-	let bhd_directory_end = bhd_directory_range.end;
-	let mut bhd_directory = efs
-		.create_bhd_directory(
-			bhd_directory_beginning,
-			bhd_directory_end,
-			bhd_directory_address_mode,
-			Some(first_payload_range_beginning),
-			&bhd_entries,
-		)
-		.map_err(efs_to_io_error)?;
+    let bhd_entries = bhd_raw_entries
+        .iter()
+        .map(|(raw_entry, _, _)| raw_entry.clone())
+        .collect::<Vec<BhdDirectoryEntry>>();
+    let (bhd_directory_range, payload_range) =
+        payload_range.split_at_least(bhd_directory_size as usize);
+    let bhd_directory_beginning = bhd_directory_range.beginning;
+    let bhd_directory_end = bhd_directory_range.end;
+    let mut bhd_directory = efs
+        .create_bhd_directory(
+            bhd_directory_beginning,
+            bhd_directory_end,
+            bhd_directory_address_mode,
+            Some(first_payload_range_beginning),
+            &bhd_entries,
+        )
+        .map_err(efs_to_io_error)?;
 
-	bhd_directory
-		.save(storage, bhd_directory_range, first_payload_range_beginning)
-		.map_err(efs_to_io_error)?;
-	Ok(payload_range)
+    bhd_directory
+        .save(storage, bhd_directory_range, first_payload_range_beginning)
+        .map_err(efs_to_io_error)?;
+    Ok(payload_range)
 }
 
 fn run() -> std::io::Result<()> {
-	//let args: Vec<String> = env::args().collect();
-	let opts = Opts::from_args();
-	let filename = &opts.output_filename;
-	let efs_to_io_error = |e: amd_efs::Error| {
-		std::io::Error::new(
-			std::io::ErrorKind::Other,
-			format!("EFS error: {:?} in file {:?}", e, filename),
-		)
-	};
-	let flash_to_io_error = |e: amd_flash::Error| {
-		std::io::Error::new(
-			std::io::ErrorKind::Other,
-			format!("Flash error: {:?} in file {:?}", e, filename),
-		)
-	};
-	let apcb_to_io_error = |e| {
-		std::io::Error::new(
-			std::io::ErrorKind::Other,
-			format!(
-				"APCB error: {:?} in file {:?}",
-				e, opts.efs_configuration_filename
-			),
-		)
-	};
-	let json5_to_io_error = |e: json5::Error| match e {
-		json5::Error::Message {
-			ref msg,
-			ref location,
-		} => std::io::Error::new(
-			std::io::ErrorKind::Other,
-			format!(
-				"JSON5 error: {} in file {:?} at {}",
-				msg,
-				opts.efs_configuration_filename,
-				match location {
-					None => "unknown location".to_owned(),
-					Some(x) => format!("{:?}", x),
-				}
-			),
-		),
-	};
-	let amd_host_image_builder_config_error_to_io_error =
-		|e: amd_host_image_builder_config::Error| {
-			std::io::Error::new(
-				std::io::ErrorKind::Other,
-				format!(
-					"Config error: {:?} in file {:?}",
-					e, opts.reset_image_filename
-				),
-			)
-		};
+    //let args: Vec<String> = env::args().collect();
+    let opts = Opts::from_args();
+    let filename = &opts.output_filename;
+    let efs_to_io_error = |e: amd_efs::Error| {
+        std::io::Error::new(
+            std::io::ErrorKind::Other,
+            format!("EFS error: {:?} in file {:?}", e, filename),
+        )
+    };
+    let flash_to_io_error = |e: amd_flash::Error| {
+        std::io::Error::new(
+            std::io::ErrorKind::Other,
+            format!("Flash error: {:?} in file {:?}", e, filename),
+        )
+    };
+    let apcb_to_io_error = |e| {
+        std::io::Error::new(
+            std::io::ErrorKind::Other,
+            format!(
+                "APCB error: {:?} in file {:?}",
+                e, opts.efs_configuration_filename
+            ),
+        )
+    };
+    let json5_to_io_error = |e: json5::Error| match e {
+        json5::Error::Message { ref msg, ref location } => std::io::Error::new(
+            std::io::ErrorKind::Other,
+            format!(
+                "JSON5 error: {} in file {:?} at {}",
+                msg,
+                opts.efs_configuration_filename,
+                match location {
+                    None => "unknown location".to_owned(),
+                    Some(x) => format!("{:?}", x),
+                }
+            ),
+        ),
+    };
+    let amd_host_image_builder_config_error_to_io_error =
+        |e: amd_host_image_builder_config::Error| {
+            std::io::Error::new(
+                std::io::ErrorKind::Other,
+                format!(
+                    "Config error: {:?} in file {:?}",
+                    e, opts.reset_image_filename
+                ),
+            )
+        };
 
-	let file = OpenOptions::new()
-		.read(true)
-		.write(true)
-		.create(true)
-		.open(filename)?;
-	file.set_len(static_config::IMAGE_SIZE.into())?;
-	const ERASABLE_BLOCK_SIZE: usize = 0x1000;
-	const_assert!(ERASABLE_BLOCK_SIZE.is_power_of_two());
-	let mut storage = FlashImage::new(file, &filename, ERASABLE_BLOCK_SIZE);
-	let payload_range = ErasableRange::new(
-		storage.erasable_location(static_config::PAYLOAD_BEGINNING)
-			.ok_or(amd_efs::Error::Misaligned)
-			.map_err(efs_to_io_error)?,
-		storage.erasable_location(static_config::PAYLOAD_END)
-			.ok_or(amd_efs::Error::Misaligned)
-			.map_err(efs_to_io_error)?,
-	);
-	let erasable_block_size = storage.erasable_block_size();
-	let mut position: AlignedLocation = storage
-		.erasable_location(0)
-		.ok_or(amd_flash::Error::Alignment)
-		.map_err(flash_to_io_error)?;
-	while Location::from(position) < static_config::IMAGE_SIZE {
-		FlashWrite::erase_block(&mut storage, position)
-			.map_err(flash_to_io_error)?;
-		position = position
-			.advance(erasable_block_size)
-			.map_err(flash_to_io_error)?;
-	}
-	assert!(Location::from(position) == static_config::IMAGE_SIZE);
-	let path = Path::new(&opts.efs_configuration_filename);
-	let data = std::fs::read_to_string(path)?;
-	let config: SerdeConfig =
-		json5::from_str(&data).map_err(json5_to_io_error)?;
+    let file = OpenOptions::new()
+        .read(true)
+        .write(true)
+        .create(true)
+        .open(filename)?;
+    file.set_len(static_config::IMAGE_SIZE.into())?;
+    const ERASABLE_BLOCK_SIZE: usize = 0x1000;
+    const_assert!(ERASABLE_BLOCK_SIZE.is_power_of_two());
+    let mut storage = FlashImage::new(file, &filename, ERASABLE_BLOCK_SIZE);
+    let payload_range = ErasableRange::new(
+        storage
+            .erasable_location(static_config::PAYLOAD_BEGINNING)
+            .ok_or(amd_efs::Error::Misaligned)
+            .map_err(efs_to_io_error)?,
+        storage
+            .erasable_location(static_config::PAYLOAD_END)
+            .ok_or(amd_efs::Error::Misaligned)
+            .map_err(efs_to_io_error)?,
+    );
+    let erasable_block_size = storage.erasable_block_size();
+    let mut position: AlignedLocation = storage
+        .erasable_location(0)
+        .ok_or(amd_flash::Error::Alignment)
+        .map_err(flash_to_io_error)?;
+    while Location::from(position) < static_config::IMAGE_SIZE {
+        FlashWrite::erase_block(&mut storage, position)
+            .map_err(flash_to_io_error)?;
+        position =
+            position.advance(erasable_block_size).map_err(flash_to_io_error)?;
+    }
+    assert!(Location::from(position) == static_config::IMAGE_SIZE);
+    let path = Path::new(&opts.efs_configuration_filename);
+    let data = std::fs::read_to_string(path)?;
+    let config: SerdeConfig =
+        json5::from_str(&data).map_err(json5_to_io_error)?;
 
-	let SerdeConfig {
-		processor_generation,
-		spi_mode_bulldozer,
-		spi_mode_zen_naples,
-		spi_mode_zen_rome,
-		psp,
-		bhd,
-	} = config;
-	let host_processor_generation = processor_generation;
-	let mut efs = match Efs::<_>::create(
-		&storage,
-		host_processor_generation,
-		static_config::EFH_BEGINNING(host_processor_generation),
-		Some(static_config::IMAGE_SIZE),
-	) {
-		Ok(efs) => efs,
-		Err(e) => {
-			eprintln!("Error on creation: {:?}", e);
-			std::process::exit(1);
-		}
-	};
-	efs.set_spi_mode_bulldozer(spi_mode_bulldozer);
-	efs.set_spi_mode_zen_naples(spi_mode_zen_naples);
-	efs.set_spi_mode_zen_rome(spi_mode_zen_rome);
-	let blobdirs = &opts.blobdirs;
-	let resolve_blob =
-		|blob_filename: PathBuf| -> std::io::Result<PathBuf> {
-			if blob_filename.has_root() {
-				if blob_filename.exists() {
-					Ok(blob_filename.to_path_buf())
-				} else {
-					Err(std::io::Error::new(
-			                        std::io::ErrorKind::Other,
-			                        format!("Blob read error: Could not find file {:?}", blob_filename),
-			                ))
-				}
-			} else {
-				for blobdir in blobdirs {
-					let fullname =
-						blobdir.join(&blob_filename);
-					if fullname.exists() {
-						if opts.verbose {
-							eprintln!("Info: Using blob {:?}", fullname);
-						}
-						return Ok(fullname);
-					}
-				}
-				Err(std::io::Error::new(
-		                        std::io::ErrorKind::Other,
-		                        format!("Blob read error: Could not find file {:?} \
-(neither directly nor in any of the directories {:?})", blob_filename, blobdirs),
-		                ))
-			}
-		};
+    let SerdeConfig {
+        processor_generation,
+        spi_mode_bulldozer,
+        spi_mode_zen_naples,
+        spi_mode_zen_rome,
+        psp,
+        bhd,
+    } = config;
+    let host_processor_generation = processor_generation;
+    let mut efs = match Efs::<_>::create(
+        &storage,
+        host_processor_generation,
+        static_config::EFH_BEGINNING(host_processor_generation),
+        Some(static_config::IMAGE_SIZE),
+    ) {
+        Ok(efs) => efs,
+        Err(e) => {
+            eprintln!("Error on creation: {:?}", e);
+            std::process::exit(1);
+        }
+    };
+    efs.set_spi_mode_bulldozer(spi_mode_bulldozer);
+    efs.set_spi_mode_zen_naples(spi_mode_zen_naples);
+    efs.set_spi_mode_zen_rome(spi_mode_zen_rome);
+    let blobdirs = &opts.blobdirs;
+    let resolve_blob = |blob_filename: PathBuf| -> std::io::Result<PathBuf> {
+        if blob_filename.has_root() {
+            if blob_filename.exists() {
+                Ok(blob_filename.to_path_buf())
+            } else {
+                Err(std::io::Error::new(
+                    std::io::ErrorKind::Other,
+                    format!(
+                        "Blob read error: Could not find file {:?}",
+                        blob_filename
+                    ),
+                ))
+            }
+        } else {
+            for blobdir in blobdirs {
+                let fullname = blobdir.join(&blob_filename);
+                if fullname.exists() {
+                    if opts.verbose {
+                        eprintln!("Info: Using blob {:?}", fullname);
+                    }
+                    return Ok(fullname);
+                }
+            }
+            Err(std::io::Error::new(
+                std::io::ErrorKind::Other,
+                format!(
+                    "Blob read error: Could not find file {:?} \
+(neither directly nor in any of the directories {:?})",
+                    blob_filename, blobdirs
+                ),
+            ))
+        }
+    };
 
-	// ================================ PSP =============================
+    // ================================ PSP =============================
 
-	let mut abl0_version: Option<u32> = None;
-	let mut abl0_version_found = false;
-	let psp_directory_address_mode = AddressMode::EfsRelativeOffset;
-	let mut psp_raw_entries = match psp {
-		SerdePspDirectoryVariant::PspDirectory(
-			ref serde_psp_directory,
-		) => {
-			serde_psp_directory.entries.iter().map(|entry| {
+    let mut abl0_version: Option<u32> = None;
+    let mut abl0_version_found = false;
+    let psp_directory_address_mode = AddressMode::EfsRelativeOffset;
+    let mut psp_raw_entries = match psp {
+        SerdePspDirectoryVariant::PspDirectory(ref serde_psp_directory) => {
+            serde_psp_directory.entries.iter().map(|entry| {
 				let mut raw_entry = PspDirectoryEntry::try_from_with_context(
 					psp_directory_address_mode,
 					&entry.target
@@ -795,160 +779,156 @@ fn run() -> std::io::Result<()> {
 				}
 			})
 			.collect::<Vec<(PspDirectoryEntry, Option<Location>, Option<Vec<u8>>)>>()
-		}
-		_ => {
-			todo!();
-		}
-	};
-	if let Some(abl0_version) = abl0_version {
-		if opts.verbose {
-			// See AgesaBLReleaseNotes.txt, section "ABL Version String"
-			println!("Info: Abl0 version: 0x{:x}", abl0_version)
-		}
-	}
+        }
+        _ => {
+            todo!();
+        }
+    };
+    if let Some(abl0_version) = abl0_version {
+        if opts.verbose {
+            // See AgesaBLReleaseNotes.txt, section "ABL Version String"
+            println!("Info: Abl0 version: 0x{:x}", abl0_version)
+        }
+    }
 
-	let payload_range = save_psp_directory(
-		&mut psp_raw_entries,
-		psp_directory_address_mode,
-		&storage,
-		payload_range,
-		&mut efs,
-	)?;
+    let payload_range = save_psp_directory(
+        &mut psp_raw_entries,
+        psp_directory_address_mode,
+        &storage,
+        payload_range,
+        &mut efs,
+    )?;
 
-	// ================================ BHD =============================
+    // ================================ BHD =============================
 
-	let bhd_directory_address_mode = AddressMode::EfsRelativeOffset;
-	let mut bhd_raw_entries = match bhd {
-		SerdeBhdDirectoryVariant::BhdDirectory(serde_bhd_directory) => {
-			serde_bhd_directory.entries.into_iter().map(|entry| {
-				let mut raw_entry = BhdDirectoryEntry::try_from_with_context(
-					bhd_directory_address_mode,
-					&entry.target
-				).unwrap();
-				let blob_slot_settings = entry.target.blob;
-				let flash_location = blob_slot_settings.as_ref().and_then(|x| x.flash_location);
-				let x: Option<Location> = flash_location
-					.map(|x| x.try_into().unwrap());
+    let bhd_directory_address_mode = AddressMode::EfsRelativeOffset;
+    let mut bhd_raw_entries = match bhd {
+        SerdeBhdDirectoryVariant::BhdDirectory(serde_bhd_directory) => {
+            serde_bhd_directory.entries.into_iter().map(|entry| {
+                let mut raw_entry = BhdDirectoryEntry::try_from_with_context(
+                    bhd_directory_address_mode,
+                    &entry.target,
+                )
+                .unwrap();
+                let blob_slot_settings = entry.target.blob;
+                let flash_location =
+                    blob_slot_settings.as_ref().and_then(|x| x.flash_location);
+                let x: Option<Location> =
+                    flash_location.map(|x| x.try_into().unwrap());
 
-				// done by try_from: raw_entry.set_destination_location(ram_destination_address);
-				// done by try_from: raw_entry.set_size(size);
-				match entry.source {
-					SerdeBhdSource::BlobFile(
-						blob_filename
-					) => {
-						let blob_filename = resolve_blob(blob_filename).unwrap();
-						let body = std::fs::read(blob_filename).unwrap();
-						raw_entry.set_size(Some(body.len().try_into().unwrap()));
-						(raw_entry, x, Some(body))
-					}
-					SerdeBhdSource::ApcbJson(apcb) => {
-						// Note: We need to do this
-						// manually because validation
-						// needs ABL0_VERSION.
-						apcb.validate(abl0_version)
-							.map_err(apcb_to_io_error).unwrap();
-						let buf = apcb
-							.save_no_inc()
-							.map_err(apcb_to_io_error).unwrap();
-						let bufref = buf.as_ref();
-						if raw_entry.size().is_none() {
-							raw_entry.set_size(
-								Some(bufref
-									.len()
-									.try_into(
-									)
-									.unwrap(
-									)),
-							);
-						};
+                // done by try_from: raw_entry.set_destination_location(ram_destination_address);
+                // done by try_from: raw_entry.set_size(size);
+                match entry.source {
+                    SerdeBhdSource::BlobFile(blob_filename) => {
+                        let blob_filename =
+                            resolve_blob(blob_filename).unwrap();
+                        let body = std::fs::read(blob_filename).unwrap();
+                        raw_entry
+                            .set_size(Some(body.len().try_into().unwrap()));
+                        (raw_entry, x, Some(body))
+                    }
+                    SerdeBhdSource::ApcbJson(apcb) => {
+                        // Note: We need to do this
+                        // manually because validation
+                        // needs ABL0_VERSION.
+                        apcb.validate(abl0_version)
+                            .map_err(apcb_to_io_error)
+                            .unwrap();
+                        let buf = apcb
+                            .save_no_inc()
+                            .map_err(apcb_to_io_error)
+                            .unwrap();
+                        let bufref = buf.as_ref();
+                        if raw_entry.size().is_none() {
+                            raw_entry.set_size(Some(
+                                bufref.len().try_into().unwrap(),
+                            ));
+                        };
 
-						(raw_entry, None, Some(buf.into_owned()))
-					}
-				}
-			})
-		}
-		_ => {
-			todo!();
-		}
-	}.collect::<Vec<(BhdDirectoryEntry, Option<Location>, Option<Vec<u8>>)>>();
+                        (raw_entry, None, Some(buf.into_owned()))
+                    }
+                }
+            })
+        }
+        _ => {
+            todo!();
+        }
+    }
+    .collect::<Vec<(BhdDirectoryEntry, Option<Location>, Option<Vec<u8>>)>>();
 
-	let apob_entry = BhdDirectoryEntry::new_payload(
-		AddressMode::PhysicalAddress,
-		BhdDirectoryEntryType::Apob,
-		Some(0),
-		Some(ValueOrLocation::PhysicalAddress(0)),
-		Some(0x400_0000),
-	)
-	.unwrap();
-	bhd_raw_entries.push((apob_entry, None, None));
+    let apob_entry = BhdDirectoryEntry::new_payload(
+        AddressMode::PhysicalAddress,
+        BhdDirectoryEntryType::Apob,
+        Some(0),
+        Some(ValueOrLocation::PhysicalAddress(0)),
+        Some(0x400_0000),
+    )
+    .unwrap();
+    bhd_raw_entries.push((apob_entry, None, None));
 
-	let (reset_image_entry, reset_image_body) =
-		bhd_directory_add_reset_image(
-			&opts.reset_image_filename,
-		)
-		.map_err(amd_host_image_builder_config_error_to_io_error)?;
-	bhd_raw_entries.push((
-		reset_image_entry,
-		Some(static_config::RESET_IMAGE_BEGINNING),
-		Some(reset_image_body),
-	));
+    let (reset_image_entry, reset_image_body) =
+        bhd_directory_add_reset_image(&opts.reset_image_filename)
+            .map_err(amd_host_image_builder_config_error_to_io_error)?;
+    bhd_raw_entries.push((
+        reset_image_entry,
+        Some(static_config::RESET_IMAGE_BEGINNING),
+        Some(reset_image_body),
+    ));
 
-	let payload_range = save_bhd_directory(
-		&mut bhd_raw_entries,
-		bhd_directory_address_mode,
-		&storage,
-		payload_range,
-		&mut efs,
-	)?;
-	drop(payload_range);
+    let payload_range = save_bhd_directory(
+        &mut bhd_raw_entries,
+        bhd_directory_address_mode,
+        &storage,
+        payload_range,
+        &mut efs,
+    )?;
+    drop(payload_range);
 
-	// ============================== Payloads =========================
+    // ============================== Payloads =========================
 
-	for (raw_entry, _, blob_body) in psp_raw_entries {
-		//eprintln!("PSP entry {:?}", raw_entry);
-		if let Some(blob_body) = blob_body {
-			let source = match raw_entry
-				.source(bhd_directory_address_mode)
-				.unwrap()
-			{
-				ValueOrLocation::EfsRelativeOffset(x) => {
-					storage.erasable_location(x).unwrap()
-				}
-				_ => {
-					todo!()
-				}
-			};
-			storage.erase_and_write_blocks(source, &blob_body)
-				.map_err(flash_to_io_error)?;
-		}
-	}
+    for (raw_entry, _, blob_body) in psp_raw_entries {
+        //eprintln!("PSP entry {:?}", raw_entry);
+        if let Some(blob_body) = blob_body {
+            let source =
+                match raw_entry.source(bhd_directory_address_mode).unwrap() {
+                    ValueOrLocation::EfsRelativeOffset(x) => {
+                        storage.erasable_location(x).unwrap()
+                    }
+                    _ => {
+                        todo!()
+                    }
+                };
+            storage
+                .erase_and_write_blocks(source, &blob_body)
+                .map_err(flash_to_io_error)?;
+        }
+    }
 
-	for (raw_entry, _, blob_body) in bhd_raw_entries {
-		//eprintln!("BHD entry {:?}", raw_entry);
-		if let Some(blob_body) = blob_body {
-			let source = match raw_entry
-				.source(bhd_directory_address_mode)
-				.unwrap()
-			{
-				ValueOrLocation::EfsRelativeOffset(x) => {
-					storage.erasable_location(x).unwrap()
-				}
-				x => {
-					eprintln!("{:?}", x);
-					todo!()
-				}
-			};
-			storage.erase_and_write_blocks(source, &blob_body)
-				.map_err(flash_to_io_error)?;
-		}
-	}
+    for (raw_entry, _, blob_body) in bhd_raw_entries {
+        //eprintln!("BHD entry {:?}", raw_entry);
+        if let Some(blob_body) = blob_body {
+            let source =
+                match raw_entry.source(bhd_directory_address_mode).unwrap() {
+                    ValueOrLocation::EfsRelativeOffset(x) => {
+                        storage.erasable_location(x).unwrap()
+                    }
+                    x => {
+                        eprintln!("{:?}", x);
+                        todo!()
+                    }
+                };
+            storage
+                .erase_and_write_blocks(source, &blob_body)
+                .map_err(flash_to_io_error)?;
+        }
+    }
 
-	Ok(())
+    Ok(())
 }
 
 fn main() -> std::io::Result<()> {
-	run().map_err(|e| {
-		eprintln!("Error: {}", e);
-		std::process::exit(1);
-	})
+    run().map_err(|e| {
+        eprintln!("Error: {}", e);
+        std::process::exit(1);
+    })
 }

--- a/src/static_config.rs
+++ b/src/static_config.rs
@@ -71,12 +71,10 @@ These point to PSP payloads and BHD payloads, respectively.
 /// generation, you have to adapt this file--and that's on purpose.
 #[allow(non_snake_case)]
 pub(crate) const fn EFH_BEGINNING(
-	processor_generation: ProcessorGeneration,
+    processor_generation: ProcessorGeneration,
 ) -> Location {
-	match processor_generation {
-		ProcessorGeneration::Naples => 0x2_0000,
-		ProcessorGeneration::Rome | ProcessorGeneration::Milan => {
-			0xFA_0000
-		}
-	}
+    match processor_generation {
+        ProcessorGeneration::Naples => 0x2_0000,
+        ProcessorGeneration::Rome | ProcessorGeneration::Milan => 0xFA_0000,
+    }
 }

--- a/tests/schema.rs
+++ b/tests/schema.rs
@@ -4,36 +4,36 @@ use valico::json_schema;
 #[macro_use]
 extern crate pathsep;
 const SCHEMA_STR: &str =
-	include_str!(join_path!(env!("OUT_DIR"), "efs.schema.json"));
+    include_str!(join_path!(env!("OUT_DIR"), "efs.schema.json"));
 
 #[test]
 fn test_schema() {
-	// Make sure our test efs config validates using the schema we just
-	// generated.
-	let schema_json: serde_json::Value =
-		serde_json::from_str(SCHEMA_STR).expect("Schema");
-	let configuration_filename =
-		Path::new("test-inputs").join("Milan.efs.json5");
-	let configuration_str = std::fs::read_to_string(configuration_filename)
-		.expect("configuration");
-	let configuration_json: serde_json::Value =
-		json5::from_str(&configuration_str)
-			.expect("configuration be valid JSON");
-	let mut scope = json_schema::Scope::new();
-	let schema_validator = scope
-		.compile_and_return(schema_json.clone(), false)
-		.expect("schema be valid");
-	let state = schema_validator.validate(&configuration_json);
-	if !state.is_valid() {
-		let errors = state.errors;
-		for error in errors {
-			eprintln!(
-				"validation error: {}, {}, {:#?}",
-				error,
-				error.get_title(),
-				error.get_detail()
-			);
-		}
-		panic!("validation error");
-	}
+    // Make sure our test efs config validates using the schema we just
+    // generated.
+    let schema_json: serde_json::Value =
+        serde_json::from_str(SCHEMA_STR).expect("Schema");
+    let configuration_filename =
+        Path::new("test-inputs").join("Milan.efs.json5");
+    let configuration_str =
+        std::fs::read_to_string(configuration_filename).expect("configuration");
+    let configuration_json: serde_json::Value =
+        json5::from_str(&configuration_str)
+            .expect("configuration be valid JSON");
+    let mut scope = json_schema::Scope::new();
+    let schema_validator = scope
+        .compile_and_return(schema_json.clone(), false)
+        .expect("schema be valid");
+    let state = schema_validator.validate(&configuration_json);
+    if !state.is_valid() {
+        let errors = state.errors;
+        for error in errors {
+            eprintln!(
+                "validation error: {}, {}, {:#?}",
+                error,
+                error.get_title(),
+                error.get_detail()
+            );
+        }
+        panic!("validation error");
+    }
 }

--- a/tests/versioning.rs
+++ b/tests/versioning.rs
@@ -1,97 +1,105 @@
-use std::path::Path;
 use amd_apcb::Error;
-use amd_host_image_builder_config::{SerdeBhdDirectoryVariant, SerdeBhdSource, SerdeConfig};
+use amd_host_image_builder_config::{
+    SerdeBhdDirectoryVariant, SerdeBhdSource, SerdeConfig,
+};
+use std::path::Path;
 
 #[test]
 fn test_token_versioning() {
-        let configuration_filename =
-                Path::new("test-inputs").join("Milan.efs.json5");
-        let configuration_str = std::fs::read_to_string(configuration_filename).unwrap();
-        let configuration: SerdeConfig = json5::from_str(&configuration_str).unwrap();
-        match configuration.bhd {
-                SerdeBhdDirectoryVariant::BhdDirectory(directory) => {
-                        let mut found_match = false;
-                        for entry in directory.entries {
-                                match entry.source {
-                                        SerdeBhdSource::BlobFile(_) => {}
-                                        SerdeBhdSource::ApcbJson(apcb) => {
-                                                found_match = true;
-                                                apcb.validate(None).unwrap();
-                                                apcb.validate(Some(0x42)).unwrap();
-                                        }
-                                }
-                        }
-                        assert!(found_match);
-
+    let configuration_filename =
+        Path::new("test-inputs").join("Milan.efs.json5");
+    let configuration_str =
+        std::fs::read_to_string(configuration_filename).unwrap();
+    let configuration: SerdeConfig =
+        json5::from_str(&configuration_str).unwrap();
+    match configuration.bhd {
+        SerdeBhdDirectoryVariant::BhdDirectory(directory) => {
+            let mut found_match = false;
+            for entry in directory.entries {
+                match entry.source {
+                    SerdeBhdSource::BlobFile(_) => {}
+                    SerdeBhdSource::ApcbJson(apcb) => {
+                        found_match = true;
+                        apcb.validate(None).unwrap();
+                        apcb.validate(Some(0x42)).unwrap();
+                    }
                 }
-                _ => panic!("test input is unexpected. Please update test")
+            }
+            assert!(found_match);
         }
+        _ => panic!("test input is unexpected. Please update test"),
+    }
 }
 
 #[test]
 fn test_token_versioning_failure() {
-        let configuration_filename =
-                Path::new("test-inputs").join("Milan-new.efs.json5");
-        let configuration_str = std::fs::read_to_string(configuration_filename).unwrap();
-        let configuration: SerdeConfig = json5::from_str(&configuration_str).unwrap();
-        match configuration.bhd {
-                SerdeBhdDirectoryVariant::BhdDirectory(directory) => {
-                        let mut found_match = false;
-                        for entry in directory.entries {
-                                match entry.source {
-                                        SerdeBhdSource::BlobFile(_) => {}
-                                        SerdeBhdSource::ApcbJson(apcb) => {
-                                                found_match = true;
-                                                apcb.validate(None).unwrap();
-                                                match apcb.validate(Some(0x42)) {
-                                                        Err(Error::TokenVersionMismatch { .. }) => {
-
-                                                        },
-                                                        Err(x) => {
-                                                                panic!("test failed with unexpected error {:?}", x)
-                                                        }
-                                                        Ok(_) => {
-                                                                panic!("test unexpectedly succeeded")
-                                                        }
-                                                }
-                                        }
-                                }
+    let configuration_filename =
+        Path::new("test-inputs").join("Milan-new.efs.json5");
+    let configuration_str =
+        std::fs::read_to_string(configuration_filename).unwrap();
+    let configuration: SerdeConfig =
+        json5::from_str(&configuration_str).unwrap();
+    match configuration.bhd {
+        SerdeBhdDirectoryVariant::BhdDirectory(directory) => {
+            let mut found_match = false;
+            for entry in directory.entries {
+                match entry.source {
+                    SerdeBhdSource::BlobFile(_) => {}
+                    SerdeBhdSource::ApcbJson(apcb) => {
+                        found_match = true;
+                        apcb.validate(None).unwrap();
+                        match apcb.validate(Some(0x42)) {
+                            Err(Error::TokenVersionMismatch { .. }) => {}
+                            Err(x) => {
+                                panic!(
+                                    "test failed with unexpected error {:?}",
+                                    x
+                                )
+                            }
+                            Ok(_) => {
+                                panic!("test unexpectedly succeeded")
+                            }
                         }
-                        assert!(found_match);
-
+                    }
                 }
-                _ => panic!("test input is unexpected. Please update test")
+            }
+            assert!(found_match);
         }
+        _ => panic!("test input is unexpected. Please update test"),
+    }
 }
 
 #[test]
 fn test_token_versioning_both_new() {
-        let configuration_filename =
-                Path::new("test-inputs").join("Milan-new.efs.json5");
-        let configuration_str = std::fs::read_to_string(configuration_filename).unwrap();
-        let configuration: SerdeConfig = json5::from_str(&configuration_str).unwrap();
-        match configuration.bhd {
-                SerdeBhdDirectoryVariant::BhdDirectory(directory) => {
-                        let mut found_match = false;
-                        for entry in directory.entries {
-                                match entry.source {
-                                        SerdeBhdSource::BlobFile(_) => {}
-                                        SerdeBhdSource::ApcbJson(apcb) => {
-                                                found_match = true;
-                                                apcb.validate(None).unwrap();
-                                                match apcb.validate(Some(0x1004_5012)) {
-                                                        Err(x) => {
-                                                                panic!("test failed with unexpected error {:?}", x)
-                                                        }
-                                                        Ok(_) => {
-                                                        }
-                                                }
-                                        }
-                                }
+    let configuration_filename =
+        Path::new("test-inputs").join("Milan-new.efs.json5");
+    let configuration_str =
+        std::fs::read_to_string(configuration_filename).unwrap();
+    let configuration: SerdeConfig =
+        json5::from_str(&configuration_str).unwrap();
+    match configuration.bhd {
+        SerdeBhdDirectoryVariant::BhdDirectory(directory) => {
+            let mut found_match = false;
+            for entry in directory.entries {
+                match entry.source {
+                    SerdeBhdSource::BlobFile(_) => {}
+                    SerdeBhdSource::ApcbJson(apcb) => {
+                        found_match = true;
+                        apcb.validate(None).unwrap();
+                        match apcb.validate(Some(0x1004_5012)) {
+                            Err(x) => {
+                                panic!(
+                                    "test failed with unexpected error {:?}",
+                                    x,
+                                )
+                            }
+                            Ok(_) => {}
                         }
-                        assert!(found_match);
-
+                    }
                 }
-                _ => panic!("test input is unexpected. Please update test")
+            }
+            assert!(found_match);
         }
+        _ => panic!("test input is unexpected. Please update test"),
+    }
 }


### PR DESCRIPTION
Use a more "standard" rustfmt.toml, and reformat
code.  While this change is large, it is purely
mechanical.