### PR TITLE
Cargo: Update amd-efs dependency to 0.2.0.

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -35,8 +35,8 @@ dependencies = [
 
 [[package]]
 name = "amd-efs"
-version = "0.1.0"
-source = "git+ssh://git@github.com/oxidecomputer/amd-efs.git?tag=v0.1.2#609d1a8d19410e47ac5efd4e78aff50dc9b5121b"
+version = "0.2.0"
+source = "git+ssh://git@github.com/oxidecomputer/amd-efs.git?tag=v0.2.0#7888fe67994916681310f8d1b656e586b0cfd9b9"
 dependencies = [
  "amd-flash",
  "byteorder",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -8,7 +8,7 @@ edition = "2018"
 
 [dependencies]
 amd-apcb = { git = "ssh://git@github.com/oxidecomputer/amd-apcb.git", tag = "v0.1.0", features = ["serde", "schemars"] }
-amd-efs = { git = "ssh://git@github.com/oxidecomputer/amd-efs.git", tag = "v0.1.2", features = ["std", "serde", "schemars"] }
+amd-efs = { git = "ssh://git@github.com/oxidecomputer/amd-efs.git", tag = "v0.2.0", features = ["std", "serde", "schemars"] }
 amd-flash = { git = "ssh://git@github.com/oxidecomputer/amd-flash.git", tag = "v0.1.1" }
 goblin = { version = "0.4", features = ["elf64", "endian_fd"] }
 #serde = { version = "1.0", default-features = false, features = ["derive"] }
@@ -24,7 +24,7 @@ pathsep="0.1.1"
 
 [build-dependencies]
 amd-apcb = { git = "ssh://git@github.com/oxidecomputer/amd-apcb.git", tag = "v0.1.0", features = ["serde", "schemars"] }
-amd-efs = { git = "ssh://git@github.com/oxidecomputer/amd-efs.git", tag = "v0.1.2", features = ["std", "serde", "schemars"] }
+amd-efs = { git = "ssh://git@github.com/oxidecomputer/amd-efs.git", tag = "v0.2.0", features = ["std", "serde", "schemars"] }
 amd-host-image-builder-config = { path = "amd-host-image-builder-config" }
 schemars = "0.8.8"
 serde_json = "1.0.78"

--- a/amd-host-image-builder-config/Cargo.toml
+++ b/amd-host-image-builder-config/Cargo.toml
@@ -7,7 +7,7 @@ edition = "2018"
 
 [dependencies]
 amd-apcb = { git = "ssh://git@github.com/oxidecomputer/amd-apcb.git", tag = "v0.1.0", features = ["serde", "schemars"] }
-amd-efs = { git = "ssh://git@github.com/oxidecomputer/amd-efs.git", tag = "v0.1.2", features = ["std", "serde", "schemars"] }
+amd-efs = { git = "ssh://git@github.com/oxidecomputer/amd-efs.git", tag = "v0.2.0", features = ["std", "serde", "schemars"] }
 amd-flash = { git = "ssh://git@github.com/oxidecomputer/amd-flash.git", tag = "v0.1.1" }
 schemars = "0.8.8"
 serde = { version = "1.0", default-features = false, features = ["derive"] }

--- a/src/main.rs
+++ b/src/main.rs
@@ -619,7 +619,7 @@ fn run() -> std::io::Result<()> {
                         let body = std::fs::read(&blob_filename).unwrap();
                         raw_entry.set_size(Some(body.len().try_into().unwrap()));
 
-                        if raw_entry.type_() == PspDirectoryEntryType::Abl0 {
+                        if let Ok(PspDirectoryEntryType::Abl0) = raw_entry.typ_or_err() {
                             let new_abl0_version = psp_file_version(&blob_filename);
                             if !abl0_version_found {
                                 abl0_version = new_abl0_version;


### PR DESCRIPTION
Fixes <https://github.com/oxidecomputer/amd-host-image-builder/issues/114>.