### PR TITLE
Update amd-efs dependency to v0.2.3.

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -27,7 +27,7 @@ dependencies = [
 [[package]]
 name = "amd-efs"
 version = "0.2.2"
-source = "git+ssh://git@github.com/oxidecomputer/amd-efs.git?tag=v0.2.2#d5a0b0998e565370362a2cceaa19577f8c5681cd"
+source = "git+ssh://git@github.com/oxidecomputer/amd-efs.git?tag=v0.2.3#8ef550d6dcad401f516259ccd2f7d56bb63abcc3"
 dependencies = [
  "amd-flash",
  "byteorder",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -8,7 +8,7 @@ edition = "2018"
 
 [dependencies]
 amd-apcb = { git = "ssh://git@github.com/oxidecomputer/amd-apcb.git", tag = "v0.1.1", features = ["serde", "schemars"] }
-amd-efs = { git = "ssh://git@github.com/oxidecomputer/amd-efs.git", tag = "v0.2.2", features = ["std", "serde", "schemars"] }
+amd-efs = { git = "ssh://git@github.com/oxidecomputer/amd-efs.git", tag = "v0.2.3", features = ["std", "serde", "schemars"] }
 amd-flash = { git = "ssh://git@github.com/oxidecomputer/amd-flash.git", tag = "v0.2.0" }
 goblin = { version = "0.4", features = ["elf64", "endian_fd"] }
 #serde = { version = "1.0", default-features = false, features = ["derive"] }

--- a/amd-host-image-builder-config/Cargo.toml
+++ b/amd-host-image-builder-config/Cargo.toml
@@ -7,7 +7,7 @@ edition = "2018"
 
 [dependencies]
 amd-apcb = { git = "ssh://git@github.com/oxidecomputer/amd-apcb.git", tag = "v0.1.1", features = ["serde", "schemars"] }
-amd-efs = { git = "ssh://git@github.com/oxidecomputer/amd-efs.git", tag = "v0.2.2", features = ["std", "serde", "schemars"] }
+amd-efs = { git = "ssh://git@github.com/oxidecomputer/amd-efs.git", tag = "v0.2.3", features = ["std", "serde", "schemars"] }
 amd-flash = { git = "ssh://git@github.com/oxidecomputer/amd-flash.git", tag = "v0.2.0" }
 schemars = "0.8.8"
 serde = { version = "1.0", default-features = false, features = ["derive"] }


### PR DESCRIPTION
Fixes <https://github.com/oxidecomputer/amd-efs/issues/64>.

Build tested successfully and ends up with the same image contents as before.
