### PR TITLE
Update amd-efs to v0.2.6.

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -25,12 +25,13 @@ dependencies = [
 
 [[package]]
 name = "amd-efs"
-version = "0.2.5"
-source = "git+ssh://git@github.com/oxidecomputer/amd-efs.git?tag=v0.2.5#6a0f830b57f0cc326a06273a70449040e16809aa"
+version = "0.2.6"
+source = "git+ssh://git@github.com/oxidecomputer/amd-efs.git?tag=v0.2.6#01747f0ab6314474ba32ad903c00cf2078de5e59"
 dependencies = [
  "amd-flash",
  "byteorder",
  "fletcher",
+ "memoffset",
  "modular-bitfield",
  "num-derive",
  "num-traits",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -8,7 +8,7 @@ edition = "2018"
 
 [dependencies]
 amd-apcb = { git = "https://github.com/oxidecomputer/amd-apcb.git", tag = "v0.1.5", features = ["std", "serde", "schemars"] }
-amd-efs = { git = "ssh://git@github.com/oxidecomputer/amd-efs.git", tag = "v0.2.5", features = ["std", "serde", "schemars"] }
+amd-efs = { git = "ssh://git@github.com/oxidecomputer/amd-efs.git", tag = "v0.2.6", features = ["std", "serde", "schemars"] }
 amd-flash = { git = "ssh://git@github.com/oxidecomputer/amd-flash.git", tag = "v0.2.1", features = ["std"] }
 goblin = { version = "0.4", features = ["elf64", "endian_fd"] }
 #serde = { version = "1.0", default-features = false, features = ["derive"] }

--- a/amd-host-image-builder-config/Cargo.toml
+++ b/amd-host-image-builder-config/Cargo.toml
@@ -7,7 +7,7 @@ edition = "2018"
 
 [dependencies]
 amd-apcb = { git = "https://github.com/oxidecomputer/amd-apcb.git", tag = "v0.1.5", features = ["std", "serde", "schemars"] }
-amd-efs = { git = "ssh://git@github.com/oxidecomputer/amd-efs.git", tag = "v0.2.5", features = ["std", "serde", "schemars"] }
+amd-efs = { git = "ssh://git@github.com/oxidecomputer/amd-efs.git", tag = "v0.2.6", features = ["std", "serde", "schemars"] }
 amd-flash = { git = "ssh://git@github.com/oxidecomputer/amd-flash.git", tag = "v0.2.1", features = ["std"] }
 schemars = "0.8.8"
 serde = { version = "1.0", default-features = false, features = ["derive"] }


### PR DESCRIPTION
Fixes <https://github.com/oxidecomputer/amd-efs/issues/87>--mistake in Spi offset inside the Efs.
