### PR TITLE
amd-host-image-builder#168 Update rust toolchain to 2023-12-30.

### DIFF
--- a/rust-toolchain
+++ b/rust-toolchain
@@ -1,3 +1,3 @@
 [toolchain]
-channel = "nightly-2023-07-30"
+channel = "nightly-2023-12-30"
 components = [ "rustfmt", "rust-src" ]


### PR DESCRIPTION
Tested by comparing image `milan-gimlet-b-1.0.0.a.img` built before and after the change.