### PR TITLE
Allow specifying the output flash image size on the command line.

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -60,6 +60,7 @@ dependencies = [
  "amd-efs",
  "amd-flash",
  "amd-host-image-builder-config",
+ "bytesize",
  "goblin",
  "json5",
  "serde_json",
@@ -125,6 +126,12 @@ name = "byteorder"
 version = "1.4.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "14c189c53d098945499cdfa7ecc63567cf3886b3332b312a5b4585d8d3a6a610"
+
+[[package]]
+name = "bytesize"
+version = "1.3.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a3e368af43e418a04d52505cf3dbc23dda4e3407ae2fa99fd0e4f308ce546acc"
 
 [[package]]
 name = "cfg-if"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -17,3 +17,4 @@ structopt = "0.3"
 amd-host-image-builder-config = { path = "amd-host-image-builder-config" }
 json5 = "0.4.1"
 static_assertions = "1.1.0"
+bytesize = "1.3.0"

--- a/src/static_config.rs
+++ b/src/static_config.rs
@@ -1,8 +1,6 @@
 use amd_efs::ProcessorGeneration;
 use amd_flash::Location;
 
-pub(crate) const IMAGE_SIZE: u32 = 32 * 1024 * 1024;
-
 /* Coarse-grained flash locations (in Byte) */
 
 /*


### PR DESCRIPTION
Fixes <https://github.com/oxidecomputer/amd-host-image-builder/issues/5>.