### PR TITLE
.gitmodules: remove nanobl-rs vestiges

### DIFF
--- a/.gitmodules
+++ b/.gitmodules
@@ -2,7 +2,3 @@
 	path = amd-firmware
 	url = git@github.com:oxidecomputer/amd-firmware.git
 	branch = master
-[submodule "nanobl-rs"]
-	path = nanobl-rs
-	url = git@github.com:oxidecomputer/nanobl-rs.git
-	branch = master

--- a/README.md
+++ b/README.md
@@ -8,7 +8,10 @@ You must use GNU make to _run_ `amd-host-image-builder` in the
 provided example configurations.
 
 Make sure that you have GNU `ld` and `as` available for building
-the test payload.
+the test payload if you intend to run tests.
+
+Run `git submodule update --init` to download AMD firmware blobs
+used when running the tool.
 
 # Usage
 


### PR DESCRIPTION
Also make sure that we do mention `git submodule` in README.md. Sadly, we still have AMD firmware blobs in a submodule, and we need to sync those as part of the initial setup.