### PR TITLE
etc: Remove _dummy values from Genoa config.

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -4,8 +4,8 @@ version = 3
 
 [[package]]
 name = "amd-apcb"
-version = "0.3.0"
-source = "git+https://github.com/oxidecomputer/amd-apcb.git?tag=v0.3.0#a3d2d8f0eaf868811a5a49d6f10fc001783ed23f"
+version = "0.3.1"
+source = "git+https://github.com/oxidecomputer/amd-apcb.git?tag=v0.3.1#d9de1bff2fe8ac3a7391953e46affecb1d66db3b"
 dependencies = [
  "byteorder",
  "four-cc",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -7,7 +7,7 @@ edition = "2018"
 # See more keys and their definitions at https://doc.rust-lang.org/cargo/reference/manifest.html
 
 [dependencies]
-amd-apcb = { git = "https://github.com/oxidecomputer/amd-apcb.git", tag = "v0.3.0", features = ["std", "serde", "schemars"] }
+amd-apcb = { git = "https://github.com/oxidecomputer/amd-apcb.git", tag = "v0.3.1", features = ["std", "serde", "schemars"] }
 amd-efs = { git = "ssh://git@github.com/oxidecomputer/amd-efs.git", tag = "v0.4.0", features = ["std", "serde", "schemars"] }
 goblin = { version = "0.4", features = ["elf64", "endian_fd"] }
 #serde = { version = "1.0", default-features = false, features = ["derive"] }

--- a/amd-host-image-builder-config/Cargo.lock
+++ b/amd-host-image-builder-config/Cargo.lock
@@ -13,8 +13,8 @@ dependencies = [
 
 [[package]]
 name = "amd-apcb"
-version = "0.3.0"
-source = "git+https://github.com/oxidecomputer/amd-apcb.git?tag=v0.3.0#a3d2d8f0eaf868811a5a49d6f10fc001783ed23f"
+version = "0.3.1"
+source = "git+https://github.com/oxidecomputer/amd-apcb.git?tag=v0.3.1#d9de1bff2fe8ac3a7391953e46affecb1d66db3b"
 dependencies = [
  "byteorder",
  "four-cc",

--- a/amd-host-image-builder-config/Cargo.toml
+++ b/amd-host-image-builder-config/Cargo.toml
@@ -6,7 +6,7 @@ edition = "2018"
 # See more keys and their definitions at https://doc.rust-lang.org/cargo/reference/manifest.html
 
 [dependencies]
-amd-apcb = { git = "https://github.com/oxidecomputer/amd-apcb.git", tag = "v0.3.0", features = ["std", "serde", "schemars"] }
+amd-apcb = { git = "https://github.com/oxidecomputer/amd-apcb.git", tag = "v0.3.1", features = ["std", "serde", "schemars"] }
 amd-efs = { git = "ssh://git@github.com/oxidecomputer/amd-efs.git", tag = "v0.4.0", features = ["std", "serde", "schemars"] }
 schemars = "0.8.8"
 serde = { version = "1.0", default-features = false, features = ["derive"] }

--- a/etc/genoa-ruby-1.0.0.0.efs.json5
+++ b/etc/genoa-ruby-1.0.0.0.efs.json5
@@ -5039,14 +5039,9 @@
                     irq_polarity: 0,
                     cputemp_rtctime_vw_enabled: false,
                     cputemp_rtctime_vw_index_select: 0,
-                    _dummy_1: 0,
-                    _dummy_2: 0,
                     cpu_temp_mmio_base: 0,
                     rtc_time_mmio_base: 0,
-                    bus_master_enabled: true,
-                    _dummy_3: 0,
-                    _dummy_4: 0,
-                    _dummy_5: 0
+                    bus_master_enabled: true
                   }
                 },
                 {

--- a/etc/genoa-ruby-1.0.0.b.efs.json5
+++ b/etc/genoa-ruby-1.0.0.b.efs.json5
@@ -6832,14 +6832,9 @@
                     irq_polarity: 0,
                     cputemp_rtctime_vw_enabled: false,
                     cputemp_rtctime_vw_index_select: 0,
-                    _dummy_1: 0,
-                    _dummy_2: 0,
                     cpu_temp_mmio_base: 0,
                     rtc_time_mmio_base: 0,
-                    bus_master_enabled: true,
-                    _dummy_3: 0,
-                    _dummy_4: 0,
-                    _dummy_5: 0
+                    bus_master_enabled: true
                   }
                 },
                 {


### PR DESCRIPTION
Fixes <https://github.com/oxidecomputer/amd-host-image-builder/issues/183>.