### PR TITLE
Remove custom APOB address.

### DIFF
--- a/etc/turin-ruby-0.0.7.3.efs.json5
+++ b/etc/turin-ruby-0.0.7.3.efs.json5
@@ -10679,13 +10679,6 @@
           }
         },
         {
-          "source": "Implied",
-          "target": {
-            "type": "Apob",
-            "ram_destination_address": 0x75ba0000
-          }
-        },
-        {
           "source": {
             "BlobFile": "APOB_NV_BRH.bin"
           },

--- a/etc/turin-ruby-0.0.8.1.efs.json5
+++ b/etc/turin-ruby-0.0.8.1.efs.json5
@@ -10671,13 +10671,6 @@
           }
         },
         {
-          "source": "Implied",
-          "target": {
-            "type": "Apob",
-            "ram_destination_address": 0x75ba0000
-          }
-        },
-        {
           "source": {
             "BlobFile": "APOB_NV_BRH.bin"
           },


### PR DESCRIPTION
Fixes <https://github.com/oxidecomputer/amd-host-image-builder/issues/195>.

See https://github.com/oxidecomputer/amd-host-image-builder/blob/e497648c733e31a386db681f0f93e93123d429f0/src/main.rs#L1625 for why this helps.