### PR TITLE
Add support for Implied ApobNvCopy BHD directory entry

### DIFF
--- a/etc/turin-cosmo-1.0.0.5.efs.json5
+++ b/etc/turin-cosmo-1.0.0.5.efs.json5
@@ -2487,15 +2487,15 @@
                   ConsoleOutControl: {
                     abl_console_out_control: {
                       enable_console_logging: true,
-                      enable_mem_flow_logging: true,
-                      enable_mem_setreg_logging: true,
+                      enable_mem_flow_logging: false,
+                      enable_mem_setreg_logging: false,
                       enable_mem_getreg_logging: false,
-                      enable_mem_status_logging: true,
+                      enable_mem_status_logging: false,
                       enable_mem_pmu_logging: true,
                       enable_mem_pmu_sram_read_logging: false,
                       enable_mem_pmu_sram_write_logging: false,
                       enable_mem_test_verbose_logging: false,
-                      enable_mem_basic_output_logging: true,
+                      enable_mem_basic_output_logging: false,
                       abl_console_port: 128
                     },
                     abl_breakpoint_control: {
@@ -11064,7 +11064,7 @@
                     },
                     {
                       Byte: {
-                        FchConsoleOutMode: "Disabled"
+                        FchConsoleOutMode: "Enabled"
                       }
                     },
                     {
@@ -11566,6 +11566,21 @@
           },
           target: {
             type: "ApcbBackup"
+          }
+        },
+        {
+          source: "Implied",
+          target: {
+            type: "Apob",
+            ram_destination_address: 0x4000000
+          }
+        },
+        {
+          source: "Implied",
+          target: {
+            type: "ApobNvCopy",
+            flash_location: 0x7000000,
+            size: 0xd0000
           }
         },
         {

--- a/etc/turin-rubyred-1.0.0.2-p1.efs.json5
+++ b/etc/turin-rubyred-1.0.0.2-p1.efs.json5
@@ -11723,7 +11723,7 @@
                     },
                     {
                       Bool: {
-                        FchCmosClearEnableMemRestore: false
+                        FchCmosClearEnableMemRestore: true
                       }
                     },
                     {
@@ -12270,21 +12270,6 @@
                     },
                     {
                       Byte: {
-                        MemMbistDataEyeSilentExecutionDdr: "Disabled"
-                      }
-                    },
-                    {
-                      Byte: {
-                        BdatSupport: "Enabled"
-                      }
-                    },
-                    {
-                      Byte: {
-                        BdatPrintData: "Disabled"
-                      }
-                    },
-                    {
-                      Byte: {
                         FchI2cI3cSmbusSelect0: "I2c"
                       }
                     },
@@ -12611,8 +12596,8 @@
                       Byte: {
                         FchConsoleOutSerialPortEspiController: {
                           espi_controller: "Controller0",
-                          io_2e_2f_disabled: false,
-                          io_4e_4f_disabled: false,
+                          io_2e_2f_disabled: true,
+                          io_4e_4f_disabled: true,
                         }
                       }
                     },
@@ -12628,7 +12613,7 @@
                     },
                     {
                       Byte: {
-                        FchConsoleOutMode: "Disabled"
+                        FchConsoleOutMode: "Enabled"
                       }
                     },
                     {
@@ -12698,7 +12683,7 @@
                     },
                     {
                       Byte: {
-                        FchConsoleOutSerialPort: "Uart1Mmio"
+                        FchConsoleOutSerialPort: "Uart0Mmio"
                       }
                     }
                   ]
@@ -13073,21 +13058,6 @@
                     },
                     {
                       Byte: {
-                        MemMbistDataEyeSilentExecutionDdr: "Disabled"
-                      }
-                    },
-                    {
-                      Byte: {
-                        BdatSupport: "Enabled"
-                      }
-                    },
-                    {
-                      Byte: {
-                        BdatPrintData: "Disabled"
-                      }
-                    },
-                    {
-                      Byte: {
                         FchI2cI3cSmbusSelect0: "I2c"
                       }
                     },
@@ -13426,8 +13396,8 @@
                       Byte: {
                         FchConsoleOutSerialPortEspiController: {
                           espi_controller: "Controller0",
-                          io_2e_2f_disabled: false,
-                          io_4e_4f_disabled: false,
+                          io_2e_2f_disabled: true,
+                          io_4e_4f_disabled: true,
                         }
                       }
                     },
@@ -13443,7 +13413,7 @@
                     },
                     {
                       Byte: {
-                        FchConsoleOutMode: "Disabled"
+                        FchConsoleOutMode: "Enabled"
                       }
                     },
                     {
@@ -13520,7 +13490,7 @@
                     },
                     {
                       Byte: {
-                        FchConsoleOutSerialPort: "Uart1Mmio"
+                        FchConsoleOutSerialPort: "Uart0Mmio"
                       }
                     }
                   ]
@@ -13965,6 +13935,13 @@
           }
         },
         {
+          "source": "Implied",
+          "target": {
+            "type": "Apob",
+            "ram_destination_address": 0x4000000
+          }
+        },
+        {
           source: {
             BlobFile: "Type0x64_AppbDdr5RdimmImem3_BRH.csbin"
           },
@@ -14153,7 +14130,13826 @@
             instance: 12,
             sub_program: 4
           }
-        }
+        },
+        {
+          source: {
+            SecondLevelDirectory: {
+              entries: [
+                {
+                  source: {
+                    ApcbJson: {
+                      version: "0.4.2",
+                      header: {
+                        signature: "APCB",
+                        header_size: 128,
+                        version: 48,
+                        unique_apcb_instance: 27473
+                      },
+                      v3_header_ext: {
+                        signature: "ECB2",
+                        struct_version: 18,
+                        data_version: 256,
+                        ext_header_size: 96,
+                        data_offset: 88,
+                        header_checksum: 0,
+                        signature_ending: "BCPA"
+                      },
+                      groups: [
+                        {
+                          header: {
+                            signature: "PSPG",
+                            group_id: 5889,
+                            header_size: 16,
+                            version: 1
+                          }
+                        },
+                        {
+                          header: {
+                            signature: "MEMG",
+                            group_id: 5892,
+                            header_size: 16,
+                            version: 1
+                          }
+                        },
+                        {
+                          header: {
+                            signature: "GNBG",
+                            group_id: 5893,
+                            header_size: 16,
+                            version: 1
+                          }
+                        },
+                        {
+                          header: {
+                            signature: "FCHG",
+                            group_id: 5894,
+                            header_size: 16,
+                            version: 1
+                          }
+                        },
+                        {
+                          header: {
+                            signature: "TOKN",
+                            group_id: 12288,
+                            header_size: 16,
+                            version: 1
+                          }
+                        }
+                      ],
+                      entries: [
+                        {
+                          header: {
+                            group_id: 5889,
+                            entry_id: 96,
+                            instance_id: 0,
+                            context_type: "Struct",
+                            context_format: "Raw",
+                            unit_size: 0,
+                            priority_mask: {
+                              hard_force: true,
+                              normal: true
+                            },
+                            key_size: 0,
+                            key_pos: 0,
+                            board_instance_mask: 65535
+                          },
+                          BoardIdGettingMethodEeprom: [
+                            {
+                              access_method: 2,
+                              i2c_controller_index: 57349,
+                              device_address: 1279,
+                              board_id_offset: 160,
+                              board_rev_offset: 16
+                            },
+                            [
+                              {
+                                id_and_rev_and_feature_mask: 18,
+                                id_and_feature_value: 0,
+                                rev_and_feature_value: "NotApplicable",
+                                board_instance_index: 61
+                              },
+                              {
+                                id_and_rev_and_feature_mask: 255,
+                                id_and_feature_value: 0,
+                                rev_and_feature_value: "NotApplicable",
+                                board_instance_index: 62
+                              },
+                              {
+                                id_and_rev_and_feature_mask: 255,
+                                id_and_feature_value: 16,
+                                rev_and_feature_value: "NotApplicable",
+                                board_instance_index: 63
+                              },
+                              {
+                                id_and_rev_and_feature_mask: 255,
+                                id_and_feature_value: 0,
+                                rev_and_feature_value: "NotApplicable",
+                                board_instance_index: 64
+                              },
+                              {
+                                id_and_rev_and_feature_mask: 255,
+                                id_and_feature_value: 16,
+                                rev_and_feature_value: "NotApplicable",
+                                board_instance_index: 65
+                              },
+                              {
+                                id_and_rev_and_feature_mask: 255,
+                                id_and_feature_value: 0,
+                                rev_and_feature_value: "NotApplicable",
+                                board_instance_index: 66
+                              },
+                              {
+                                id_and_rev_and_feature_mask: 255,
+                                id_and_feature_value: 16,
+                                rev_and_feature_value: "NotApplicable",
+                                board_instance_index: 67
+                              },
+                              {
+                                id_and_rev_and_feature_mask: 255,
+                                id_and_feature_value: 16,
+                                rev_and_feature_value: "NotApplicable",
+                                board_instance_index: 68
+                              },
+                              {
+                                id_and_rev_and_feature_mask: 1,
+                                id_and_feature_value: 0,
+                                rev_and_feature_value: "NotApplicable",
+                                board_instance_index: 68
+                              },
+                              {
+                                id_and_rev_and_feature_mask: 255,
+                                id_and_feature_value: 2,
+                                rev_and_feature_value: "NotApplicable",
+                                board_instance_index: 69
+                              },
+                              {
+                                id_and_rev_and_feature_mask: 255,
+                                id_and_feature_value: 16,
+                                rev_and_feature_value: "NotApplicable",
+                                board_instance_index: 70
+                              },
+                              {
+                                id_and_rev_and_feature_mask: 255,
+                                id_and_feature_value: 16,
+                                rev_and_feature_value: "NotApplicable",
+                                board_instance_index: 71
+                              },
+                              {
+                                id_and_rev_and_feature_mask: 255,
+                                id_and_feature_value: 0,
+                                rev_and_feature_value: "NotApplicable",
+                                board_instance_index: 72
+                              },
+                              {
+                                id_and_rev_and_feature_mask: 255,
+                                id_and_feature_value: 16,
+                                rev_and_feature_value: "NotApplicable",
+                                board_instance_index: 81
+                              },
+                              {
+                                id_and_rev_and_feature_mask: 255,
+                                id_and_feature_value: 1,
+                                rev_and_feature_value: "NotApplicable",
+                                board_instance_index: 82
+                              },
+                              {
+                                id_and_rev_and_feature_mask: 255,
+                                id_and_feature_value: 16,
+                                rev_and_feature_value: "NotApplicable",
+                                board_instance_index: 102
+                              },
+                              {
+                                id_and_rev_and_feature_mask: 255,
+                                id_and_feature_value: 0,
+                                rev_and_feature_value: "NotApplicable",
+                                board_instance_index: 103
+                              },
+                              {
+                                id_and_rev_and_feature_mask: 255,
+                                id_and_feature_value: 1,
+                                rev_and_feature_value: "NotApplicable",
+                                board_instance_index: 106
+                              },
+                              {
+                                id_and_rev_and_feature_mask: 255,
+                                id_and_feature_value: 0,
+                                rev_and_feature_value: "NotApplicable",
+                                board_instance_index: 110
+                              },
+                              {
+                                id_and_rev_and_feature_mask: 255,
+                                id_and_feature_value: 16,
+                                rev_and_feature_value: "NotApplicable",
+                                board_instance_index: 111
+                              },
+                              {
+                                id_and_rev_and_feature_mask: 255,
+                                id_and_feature_value: 16,
+                                rev_and_feature_value: "NotApplicable",
+                                board_instance_index: 114
+                              },
+                              {
+                                id_and_rev_and_feature_mask: 255,
+                                id_and_feature_value: 0,
+                                rev_and_feature_value: "NotApplicable",
+                                board_instance_index: 115
+                              },
+                              {
+                                id_and_rev_and_feature_mask: 255,
+                                id_and_feature_value: 0,
+                                rev_and_feature_value: "NotApplicable",
+                                board_instance_index: 119
+                              },
+                              {
+                                id_and_rev_and_feature_mask: 255,
+                                id_and_feature_value: 0,
+                                rev_and_feature_value: "NotApplicable",
+                                board_instance_index: 120
+                              },
+                              {
+                                id_and_rev_and_feature_mask: 255,
+                                id_and_feature_value: 1,
+                                rev_and_feature_value: {
+                                  Value: 0
+                                },
+                                board_instance_index: 0
+                              },
+                              {
+                                id_and_rev_and_feature_mask: 0,
+                                id_and_feature_value: 0,
+                                rev_and_feature_value: {
+                                  Value: 2
+                                },
+                                board_instance_index: 0
+                              },
+                              {
+                                id_and_rev_and_feature_mask: 5,
+                                id_and_feature_value: 226,
+                                rev_and_feature_value: "NotApplicable",
+                                board_instance_index: 4
+                              },
+                              {
+                                id_and_rev_and_feature_mask: 160,
+                                id_and_feature_value: 0,
+                                rev_and_feature_value: {
+                                  Value: 16
+                                },
+                                board_instance_index: 0
+                              },
+                              {
+                                id_and_rev_and_feature_mask: 18,
+                                id_and_feature_value: 0,
+                                rev_and_feature_value: "NotApplicable",
+                                board_instance_index: 61
+                              },
+                              {
+                                id_and_rev_and_feature_mask: 255,
+                                id_and_feature_value: 0,
+                                rev_and_feature_value: "NotApplicable",
+                                board_instance_index: 64
+                              },
+                              {
+                                id_and_rev_and_feature_mask: 255,
+                                id_and_feature_value: 16,
+                                rev_and_feature_value: "NotApplicable",
+                                board_instance_index: 65
+                              },
+                              {
+                                id_and_rev_and_feature_mask: 255,
+                                id_and_feature_value: 0,
+                                rev_and_feature_value: "NotApplicable",
+                                board_instance_index: 66
+                              },
+                              {
+                                id_and_rev_and_feature_mask: 255,
+                                id_and_feature_value: 16,
+                                rev_and_feature_value: "NotApplicable",
+                                board_instance_index: 82
+                              },
+                              {
+                                id_and_rev_and_feature_mask: 255,
+                                id_and_feature_value: 16,
+                                rev_and_feature_value: "NotApplicable",
+                                board_instance_index: 89
+                              },
+                              {
+                                id_and_rev_and_feature_mask: 255,
+                                id_and_feature_value: 16,
+                                rev_and_feature_value: "NotApplicable",
+                                board_instance_index: 97
+                              },
+                              {
+                                id_and_rev_and_feature_mask: 255,
+                                id_and_feature_value: 16,
+                                rev_and_feature_value: "NotApplicable",
+                                board_instance_index: 98
+                              },
+                              {
+                                id_and_rev_and_feature_mask: 255,
+                                id_and_feature_value: 16,
+                                rev_and_feature_value: "NotApplicable",
+                                board_instance_index: 99
+                              },
+                              {
+                                id_and_rev_and_feature_mask: 255,
+                                id_and_feature_value: 16,
+                                rev_and_feature_value: "NotApplicable",
+                                board_instance_index: 100
+                              },
+                              {
+                                id_and_rev_and_feature_mask: 255,
+                                id_and_feature_value: 16,
+                                rev_and_feature_value: "NotApplicable",
+                                board_instance_index: 101
+                              },
+                              {
+                                id_and_rev_and_feature_mask: 255,
+                                id_and_feature_value: 16,
+                                rev_and_feature_value: "NotApplicable",
+                                board_instance_index: 104
+                              },
+                              {
+                                id_and_rev_and_feature_mask: 255,
+                                id_and_feature_value: 0,
+                                rev_and_feature_value: "NotApplicable",
+                                board_instance_index: 105
+                              },
+                              {
+                                id_and_rev_and_feature_mask: 255,
+                                id_and_feature_value: 0,
+                                rev_and_feature_value: "NotApplicable",
+                                board_instance_index: 112
+                              },
+                              {
+                                id_and_rev_and_feature_mask: 255,
+                                id_and_feature_value: 16,
+                                rev_and_feature_value: "NotApplicable",
+                                board_instance_index: 113
+                              },
+                              {
+                                id_and_rev_and_feature_mask: 255,
+                                id_and_feature_value: 16,
+                                rev_and_feature_value: "NotApplicable",
+                                board_instance_index: 118
+                              },
+                              {
+                                id_and_rev_and_feature_mask: 255,
+                                id_and_feature_value: 16,
+                                rev_and_feature_value: {
+                                  Value: 0
+                                },
+                                board_instance_index: 0
+                              },
+                              {
+                                id_and_rev_and_feature_mask: 0,
+                                id_and_feature_value: 0,
+                                rev_and_feature_value: {
+                                  Value: 2
+                                },
+                                board_instance_index: 0
+                              },
+                              {
+                                id_and_rev_and_feature_mask: 5,
+                                id_and_feature_value: 226,
+                                rev_and_feature_value: "NotApplicable",
+                                board_instance_index: 1
+                              },
+                              {
+                                id_and_rev_and_feature_mask: 160,
+                                id_and_feature_value: 0,
+                                rev_and_feature_value: {
+                                  Value: 16
+                                },
+                                board_instance_index: 0
+                              },
+                              {
+                                id_and_rev_and_feature_mask: 18,
+                                id_and_feature_value: 0,
+                                rev_and_feature_value: "NotApplicable",
+                                board_instance_index: 73
+                              },
+                              {
+                                id_and_rev_and_feature_mask: 255,
+                                id_and_feature_value: 16,
+                                rev_and_feature_value: "NotApplicable",
+                                board_instance_index: 74
+                              },
+                              {
+                                id_and_rev_and_feature_mask: 1,
+                                id_and_feature_value: 0,
+                                rev_and_feature_value: "NotApplicable",
+                                board_instance_index: 74
+                              },
+                              {
+                                id_and_rev_and_feature_mask: 2,
+                                id_and_feature_value: 0,
+                                rev_and_feature_value: "NotApplicable",
+                                board_instance_index: 74
+                              },
+                              {
+                                id_and_rev_and_feature_mask: 255,
+                                id_and_feature_value: 2,
+                                rev_and_feature_value: "NotApplicable",
+                                board_instance_index: 75
+                              },
+                              {
+                                id_and_rev_and_feature_mask: 255,
+                                id_and_feature_value: 16,
+                                rev_and_feature_value: "NotApplicable",
+                                board_instance_index: 76
+                              },
+                              {
+                                id_and_rev_and_feature_mask: 255,
+                                id_and_feature_value: 16,
+                                rev_and_feature_value: "NotApplicable",
+                                board_instance_index: 77
+                              },
+                              {
+                                id_and_rev_and_feature_mask: 255,
+                                id_and_feature_value: 1,
+                                rev_and_feature_value: "NotApplicable",
+                                board_instance_index: 78
+                              },
+                              {
+                                id_and_rev_and_feature_mask: 255,
+                                id_and_feature_value: 16,
+                                rev_and_feature_value: "NotApplicable",
+                                board_instance_index: 107
+                              },
+                              {
+                                id_and_rev_and_feature_mask: 255,
+                                id_and_feature_value: 0,
+                                rev_and_feature_value: "NotApplicable",
+                                board_instance_index: 116
+                              },
+                              {
+                                id_and_rev_and_feature_mask: 255,
+                                id_and_feature_value: 0,
+                                rev_and_feature_value: "NotApplicable",
+                                board_instance_index: 117
+                              },
+                              {
+                                id_and_rev_and_feature_mask: 255,
+                                id_and_feature_value: 0,
+                                rev_and_feature_value: "NotApplicable",
+                                board_instance_index: 127
+                              },
+                              {
+                                id_and_rev_and_feature_mask: 255,
+                                id_and_feature_value: 0,
+                                rev_and_feature_value: {
+                                  Value: 0
+                                },
+                                board_instance_index: 0
+                              },
+                              {
+                                id_and_rev_and_feature_mask: 0,
+                                id_and_feature_value: 0,
+                                rev_and_feature_value: {
+                                  Value: 2
+                                },
+                                board_instance_index: 0
+                              },
+                              {
+                                id_and_rev_and_feature_mask: 5,
+                                id_and_feature_value: 224,
+                                rev_and_feature_value: "NotApplicable",
+                                board_instance_index: 1
+                              },
+                              {
+                                id_and_rev_and_feature_mask: 160,
+                                id_and_feature_value: 0,
+                                rev_and_feature_value: {
+                                  Value: 16
+                                },
+                                board_instance_index: 0
+                              },
+                              {
+                                id_and_rev_and_feature_mask: 18,
+                                id_and_feature_value: 0,
+                                rev_and_feature_value: "NotApplicable",
+                                board_instance_index: 73
+                              },
+                              {
+                                id_and_rev_and_feature_mask: 255,
+                                id_and_feature_value: 16,
+                                rev_and_feature_value: "NotApplicable",
+                                board_instance_index: 74
+                              },
+                              {
+                                id_and_rev_and_feature_mask: 1,
+                                id_and_feature_value: 0,
+                                rev_and_feature_value: "NotApplicable",
+                                board_instance_index: 74
+                              },
+                              {
+                                id_and_rev_and_feature_mask: 2,
+                                id_and_feature_value: 0,
+                                rev_and_feature_value: "NotApplicable",
+                                board_instance_index: 74
+                              },
+                              {
+                                id_and_rev_and_feature_mask: 255,
+                                id_and_feature_value: 2,
+                                rev_and_feature_value: "NotApplicable",
+                                board_instance_index: 75
+                              },
+                              {
+                                id_and_rev_and_feature_mask: 255,
+                                id_and_feature_value: 16,
+                                rev_and_feature_value: "NotApplicable",
+                                board_instance_index: 76
+                              },
+                              {
+                                id_and_rev_and_feature_mask: 255,
+                                id_and_feature_value: 16,
+                                rev_and_feature_value: "NotApplicable",
+                                board_instance_index: 77
+                              },
+                              {
+                                id_and_rev_and_feature_mask: 255,
+                                id_and_feature_value: 1,
+                                rev_and_feature_value: "NotApplicable",
+                                board_instance_index: 78
+                              },
+                              {
+                                id_and_rev_and_feature_mask: 255,
+                                id_and_feature_value: 16,
+                                rev_and_feature_value: {
+                                  Value: 0
+                                },
+                                board_instance_index: 0
+                              }
+                            ]
+                          ]
+                        },
+                        {
+                          header: {
+                            group_id: 5892,
+                            entry_id: 49,
+                            instance_id: 0,
+                            context_type: "Struct",
+                            context_format: "Raw",
+                            unit_size: 0,
+                            priority_mask: {
+                              normal: true
+                            },
+                            key_size: 0,
+                            key_pos: 0,
+                            board_instance_mask: 1
+                          },
+                          DimmInfoSmbusElement: [
+                            {
+                              dimm_slot_present: false,
+                              socket_id: 0,
+                              channel_id: 8,
+                              dimm_id: 0,
+                              dimm_smbus_address: 0,
+                              i2c_mux_address: 0,
+                              mux_control_address: 0,
+                              mux_channel: 0
+                            },
+                            {
+                              dimm_slot_present: true,
+                              socket_id: 0,
+                              channel_id: 8,
+                              dimm_id: 0,
+                              dimm_smbus_address: 0,
+                              i2c_mux_address: 0,
+                              mux_control_address: 0,
+                              mux_channel: 160
+                            },
+                            {
+                              dimm_slot_present: true,
+                              socket_id: 0,
+                              channel_id: 8,
+                              dimm_id: 0,
+                              dimm_smbus_address: 0,
+                              i2c_mux_address: 1,
+                              mux_control_address: 0,
+                              mux_channel: 162
+                            },
+                            {
+                              dimm_slot_present: true,
+                              socket_id: 0,
+                              channel_id: 8,
+                              dimm_id: 0,
+                              dimm_smbus_address: 0,
+                              i2c_mux_address: 2,
+                              mux_control_address: 0,
+                              mux_channel: 164
+                            },
+                            {
+                              dimm_slot_present: true,
+                              socket_id: 0,
+                              channel_id: 8,
+                              dimm_id: 0,
+                              dimm_smbus_address: 0,
+                              i2c_mux_address: 3,
+                              mux_control_address: 0,
+                              mux_channel: 166
+                            },
+                            {
+                              dimm_slot_present: true,
+                              socket_id: 0,
+                              channel_id: 8,
+                              dimm_id: 0,
+                              dimm_smbus_address: 0,
+                              i2c_mux_address: 4,
+                              mux_control_address: 0,
+                              mux_channel: 168
+                            },
+                            {
+                              dimm_slot_present: true,
+                              socket_id: 0,
+                              channel_id: 8,
+                              dimm_id: 0,
+                              dimm_smbus_address: 0,
+                              i2c_mux_address: 5,
+                              mux_control_address: 0,
+                              mux_channel: 170
+                            },
+                            {
+                              dimm_slot_present: true,
+                              socket_id: 0,
+                              channel_id: 8,
+                              dimm_id: 0,
+                              dimm_smbus_address: 0,
+                              i2c_mux_address: 6,
+                              mux_control_address: 1,
+                              mux_channel: 160
+                            },
+                            {
+                              dimm_slot_present: true,
+                              socket_id: 0,
+                              channel_id: 8,
+                              dimm_id: 0,
+                              dimm_smbus_address: 0,
+                              i2c_mux_address: 7,
+                              mux_control_address: 1,
+                              mux_channel: 162
+                            },
+                            {
+                              dimm_slot_present: true,
+                              socket_id: 0,
+                              channel_id: 8,
+                              dimm_id: 0,
+                              dimm_smbus_address: 0,
+                              i2c_mux_address: 8,
+                              mux_control_address: 1,
+                              mux_channel: 164
+                            },
+                            {
+                              dimm_slot_present: true,
+                              socket_id: 0,
+                              channel_id: 8,
+                              dimm_id: 0,
+                              dimm_smbus_address: 0,
+                              i2c_mux_address: 9,
+                              mux_control_address: 1,
+                              mux_channel: 166
+                            },
+                            {
+                              dimm_slot_present: true,
+                              socket_id: 0,
+                              channel_id: 8,
+                              dimm_id: 0,
+                              dimm_smbus_address: 0,
+                              i2c_mux_address: 10,
+                              mux_control_address: 1,
+                              mux_channel: 168
+                            },
+                            {
+                              dimm_slot_present: true,
+                              socket_id: 0,
+                              channel_id: 8,
+                              dimm_id: 0,
+                              dimm_smbus_address: 0,
+                              i2c_mux_address: 11,
+                              mux_control_address: 1,
+                              mux_channel: 170
+                            },
+                            {
+                              dimm_slot_present: true,
+                              socket_id: 0,
+                              channel_id: 8,
+                              dimm_id: 0,
+                              dimm_smbus_address: 16,
+                              i2c_mux_address: 0,
+                              mux_control_address: 2,
+                              mux_channel: 160
+                            },
+                            {
+                              dimm_slot_present: true,
+                              socket_id: 0,
+                              channel_id: 8,
+                              dimm_id: 0,
+                              dimm_smbus_address: 16,
+                              i2c_mux_address: 1,
+                              mux_control_address: 2,
+                              mux_channel: 162
+                            },
+                            {
+                              dimm_slot_present: true,
+                              socket_id: 0,
+                              channel_id: 8,
+                              dimm_id: 0,
+                              dimm_smbus_address: 16,
+                              i2c_mux_address: 2,
+                              mux_control_address: 2,
+                              mux_channel: 164
+                            },
+                            {
+                              dimm_slot_present: true,
+                              socket_id: 0,
+                              channel_id: 8,
+                              dimm_id: 0,
+                              dimm_smbus_address: 16,
+                              i2c_mux_address: 3,
+                              mux_control_address: 2,
+                              mux_channel: 166
+                            },
+                            {
+                              dimm_slot_present: true,
+                              socket_id: 0,
+                              channel_id: 8,
+                              dimm_id: 0,
+                              dimm_smbus_address: 16,
+                              i2c_mux_address: 4,
+                              mux_control_address: 2,
+                              mux_channel: 168
+                            },
+                            {
+                              dimm_slot_present: true,
+                              socket_id: 0,
+                              channel_id: 8,
+                              dimm_id: 0,
+                              dimm_smbus_address: 16,
+                              i2c_mux_address: 5,
+                              mux_control_address: 2,
+                              mux_channel: 170
+                            },
+                            {
+                              dimm_slot_present: true,
+                              socket_id: 0,
+                              channel_id: 8,
+                              dimm_id: 0,
+                              dimm_smbus_address: 16,
+                              i2c_mux_address: 6,
+                              mux_control_address: 3,
+                              mux_channel: 160
+                            },
+                            {
+                              dimm_slot_present: true,
+                              socket_id: 0,
+                              channel_id: 8,
+                              dimm_id: 0,
+                              dimm_smbus_address: 16,
+                              i2c_mux_address: 7,
+                              mux_control_address: 3,
+                              mux_channel: 162
+                            },
+                            {
+                              dimm_slot_present: true,
+                              socket_id: 0,
+                              channel_id: 8,
+                              dimm_id: 0,
+                              dimm_smbus_address: 16,
+                              i2c_mux_address: 8,
+                              mux_control_address: 3,
+                              mux_channel: 164
+                            },
+                            {
+                              dimm_slot_present: true,
+                              socket_id: 0,
+                              channel_id: 8,
+                              dimm_id: 0,
+                              dimm_smbus_address: 16,
+                              i2c_mux_address: 9,
+                              mux_control_address: 3,
+                              mux_channel: 166
+                            },
+                            {
+                              dimm_slot_present: true,
+                              socket_id: 0,
+                              channel_id: 8,
+                              dimm_id: 0,
+                              dimm_smbus_address: 16,
+                              i2c_mux_address: 10,
+                              mux_control_address: 3,
+                              mux_channel: 168
+                            },
+                            {
+                              dimm_slot_present: true,
+                              socket_id: 0,
+                              channel_id: 8,
+                              dimm_id: 0,
+                              dimm_smbus_address: 16,
+                              i2c_mux_address: 11,
+                              mux_control_address: 3,
+                              mux_channel: 170
+                            }
+                          ]
+                        },
+                        {
+                          header: {
+                            group_id: 5892,
+                            entry_id: 49,
+                            instance_id: 0,
+                            context_type: "Struct",
+                            context_format: "Raw",
+                            unit_size: 0,
+                            priority_mask: {
+                              normal: true
+                            },
+                            key_size: 0,
+                            key_pos: 0,
+                            board_instance_mask: 65535
+                          },
+                          DimmInfoSmbusElement: [
+                            {
+                              dimm_slot_present: false,
+                              socket_id: 0,
+                              channel_id: 8,
+                              dimm_id: 0,
+                              dimm_smbus_address: 0,
+                              i2c_mux_address: 0,
+                              mux_control_address: 0,
+                              mux_channel: 0
+                            },
+                            {
+                              dimm_slot_present: true,
+                              socket_id: 0,
+                              channel_id: 8,
+                              dimm_id: 0,
+                              dimm_smbus_address: 0,
+                              i2c_mux_address: 0,
+                              mux_control_address: 0,
+                              mux_channel: 160
+                            },
+                            {
+                              dimm_slot_present: true,
+                              socket_id: 0,
+                              channel_id: 8,
+                              dimm_id: 0,
+                              dimm_smbus_address: 0,
+                              i2c_mux_address: 1,
+                              mux_control_address: 0,
+                              mux_channel: 162
+                            },
+                            {
+                              dimm_slot_present: true,
+                              socket_id: 0,
+                              channel_id: 8,
+                              dimm_id: 0,
+                              dimm_smbus_address: 0,
+                              i2c_mux_address: 2,
+                              mux_control_address: 0,
+                              mux_channel: 164
+                            },
+                            {
+                              dimm_slot_present: true,
+                              socket_id: 0,
+                              channel_id: 8,
+                              dimm_id: 0,
+                              dimm_smbus_address: 0,
+                              i2c_mux_address: 3,
+                              mux_control_address: 0,
+                              mux_channel: 166
+                            },
+                            {
+                              dimm_slot_present: true,
+                              socket_id: 0,
+                              channel_id: 8,
+                              dimm_id: 0,
+                              dimm_smbus_address: 0,
+                              i2c_mux_address: 4,
+                              mux_control_address: 0,
+                              mux_channel: 168
+                            },
+                            {
+                              dimm_slot_present: true,
+                              socket_id: 0,
+                              channel_id: 8,
+                              dimm_id: 0,
+                              dimm_smbus_address: 0,
+                              i2c_mux_address: 5,
+                              mux_control_address: 0,
+                              mux_channel: 170
+                            },
+                            {
+                              dimm_slot_present: true,
+                              socket_id: 0,
+                              channel_id: 8,
+                              dimm_id: 0,
+                              dimm_smbus_address: 0,
+                              i2c_mux_address: 6,
+                              mux_control_address: 1,
+                              mux_channel: 160
+                            },
+                            {
+                              dimm_slot_present: true,
+                              socket_id: 0,
+                              channel_id: 8,
+                              dimm_id: 0,
+                              dimm_smbus_address: 0,
+                              i2c_mux_address: 7,
+                              mux_control_address: 1,
+                              mux_channel: 162
+                            },
+                            {
+                              dimm_slot_present: true,
+                              socket_id: 0,
+                              channel_id: 8,
+                              dimm_id: 0,
+                              dimm_smbus_address: 0,
+                              i2c_mux_address: 8,
+                              mux_control_address: 1,
+                              mux_channel: 164
+                            },
+                            {
+                              dimm_slot_present: true,
+                              socket_id: 0,
+                              channel_id: 8,
+                              dimm_id: 0,
+                              dimm_smbus_address: 0,
+                              i2c_mux_address: 9,
+                              mux_control_address: 1,
+                              mux_channel: 166
+                            },
+                            {
+                              dimm_slot_present: true,
+                              socket_id: 0,
+                              channel_id: 8,
+                              dimm_id: 0,
+                              dimm_smbus_address: 0,
+                              i2c_mux_address: 10,
+                              mux_control_address: 1,
+                              mux_channel: 168
+                            },
+                            {
+                              dimm_slot_present: true,
+                              socket_id: 0,
+                              channel_id: 8,
+                              dimm_id: 0,
+                              dimm_smbus_address: 0,
+                              i2c_mux_address: 11,
+                              mux_control_address: 1,
+                              mux_channel: 170
+                            },
+                            {
+                              dimm_slot_present: true,
+                              socket_id: 0,
+                              channel_id: 8,
+                              dimm_id: 0,
+                              dimm_smbus_address: 0,
+                              i2c_mux_address: 16,
+                              mux_control_address: 0,
+                              mux_channel: 160
+                            },
+                            {
+                              dimm_slot_present: true,
+                              socket_id: 0,
+                              channel_id: 8,
+                              dimm_id: 0,
+                              dimm_smbus_address: 0,
+                              i2c_mux_address: 17,
+                              mux_control_address: 0,
+                              mux_channel: 162
+                            },
+                            {
+                              dimm_slot_present: true,
+                              socket_id: 0,
+                              channel_id: 8,
+                              dimm_id: 0,
+                              dimm_smbus_address: 0,
+                              i2c_mux_address: 18,
+                              mux_control_address: 0,
+                              mux_channel: 164
+                            },
+                            {
+                              dimm_slot_present: true,
+                              socket_id: 0,
+                              channel_id: 8,
+                              dimm_id: 0,
+                              dimm_smbus_address: 0,
+                              i2c_mux_address: 19,
+                              mux_control_address: 0,
+                              mux_channel: 166
+                            },
+                            {
+                              dimm_slot_present: true,
+                              socket_id: 0,
+                              channel_id: 8,
+                              dimm_id: 0,
+                              dimm_smbus_address: 0,
+                              i2c_mux_address: 20,
+                              mux_control_address: 0,
+                              mux_channel: 168
+                            },
+                            {
+                              dimm_slot_present: true,
+                              socket_id: 0,
+                              channel_id: 8,
+                              dimm_id: 0,
+                              dimm_smbus_address: 0,
+                              i2c_mux_address: 21,
+                              mux_control_address: 0,
+                              mux_channel: 170
+                            },
+                            {
+                              dimm_slot_present: true,
+                              socket_id: 0,
+                              channel_id: 8,
+                              dimm_id: 0,
+                              dimm_smbus_address: 0,
+                              i2c_mux_address: 22,
+                              mux_control_address: 1,
+                              mux_channel: 160
+                            },
+                            {
+                              dimm_slot_present: true,
+                              socket_id: 0,
+                              channel_id: 8,
+                              dimm_id: 0,
+                              dimm_smbus_address: 0,
+                              i2c_mux_address: 23,
+                              mux_control_address: 1,
+                              mux_channel: 162
+                            },
+                            {
+                              dimm_slot_present: true,
+                              socket_id: 0,
+                              channel_id: 8,
+                              dimm_id: 0,
+                              dimm_smbus_address: 0,
+                              i2c_mux_address: 24,
+                              mux_control_address: 1,
+                              mux_channel: 164
+                            },
+                            {
+                              dimm_slot_present: true,
+                              socket_id: 0,
+                              channel_id: 8,
+                              dimm_id: 0,
+                              dimm_smbus_address: 0,
+                              i2c_mux_address: 25,
+                              mux_control_address: 1,
+                              mux_channel: 166
+                            },
+                            {
+                              dimm_slot_present: true,
+                              socket_id: 0,
+                              channel_id: 8,
+                              dimm_id: 0,
+                              dimm_smbus_address: 0,
+                              i2c_mux_address: 26,
+                              mux_control_address: 1,
+                              mux_channel: 168
+                            },
+                            {
+                              dimm_slot_present: true,
+                              socket_id: 0,
+                              channel_id: 8,
+                              dimm_id: 0,
+                              dimm_smbus_address: 0,
+                              i2c_mux_address: 27,
+                              mux_control_address: 1,
+                              mux_channel: 170
+                            }
+                          ]
+                        },
+                        {
+                          header: {
+                            group_id: 5892,
+                            entry_id: 53,
+                            instance_id: 0,
+                            context_type: "Struct",
+                            context_format: "Raw",
+                            unit_size: 0,
+                            priority_mask: {
+                              normal: true
+                            },
+                            key_size: 0,
+                            key_pos: 0,
+                            board_instance_mask: 65535
+                          },
+                          DdrDqPinMapElement: [
+                            {
+                              lanes: [
+                                {
+                                  pins: [
+                                    0,
+                                    1,
+                                    2,
+                                    3,
+                                    4,
+                                    5,
+                                    6,
+                                    7
+                                  ]
+                                },
+                                {
+                                  pins: [
+                                    8,
+                                    9,
+                                    10,
+                                    11,
+                                    12,
+                                    13,
+                                    14,
+                                    15
+                                  ]
+                                },
+                                {
+                                  pins: [
+                                    16,
+                                    17,
+                                    18,
+                                    19,
+                                    20,
+                                    21,
+                                    22,
+                                    23
+                                  ]
+                                },
+                                {
+                                  pins: [
+                                    24,
+                                    25,
+                                    26,
+                                    27,
+                                    28,
+                                    29,
+                                    30,
+                                    31
+                                  ]
+                                },
+                                {
+                                  pins: [
+                                    0,
+                                    1,
+                                    2,
+                                    3,
+                                    4,
+                                    5,
+                                    6,
+                                    7
+                                  ]
+                                },
+                                {
+                                  pins: [
+                                    8,
+                                    9,
+                                    10,
+                                    11,
+                                    12,
+                                    13,
+                                    14,
+                                    15
+                                  ]
+                                },
+                                {
+                                  pins: [
+                                    16,
+                                    17,
+                                    18,
+                                    19,
+                                    20,
+                                    21,
+                                    22,
+                                    23
+                                  ]
+                                },
+                                {
+                                  pins: [
+                                    24,
+                                    25,
+                                    26,
+                                    27,
+                                    28,
+                                    29,
+                                    30,
+                                    31
+                                  ]
+                                }
+                              ]
+                            },
+                            {
+                              lanes: [
+                                {
+                                  pins: [
+                                    0,
+                                    1,
+                                    2,
+                                    3,
+                                    4,
+                                    5,
+                                    6,
+                                    7
+                                  ]
+                                },
+                                {
+                                  pins: [
+                                    8,
+                                    9,
+                                    10,
+                                    11,
+                                    12,
+                                    13,
+                                    14,
+                                    15
+                                  ]
+                                },
+                                {
+                                  pins: [
+                                    16,
+                                    17,
+                                    18,
+                                    19,
+                                    20,
+                                    21,
+                                    22,
+                                    23
+                                  ]
+                                },
+                                {
+                                  pins: [
+                                    24,
+                                    25,
+                                    26,
+                                    27,
+                                    28,
+                                    29,
+                                    30,
+                                    31
+                                  ]
+                                },
+                                {
+                                  pins: [
+                                    0,
+                                    1,
+                                    2,
+                                    3,
+                                    4,
+                                    5,
+                                    6,
+                                    7
+                                  ]
+                                },
+                                {
+                                  pins: [
+                                    8,
+                                    9,
+                                    10,
+                                    11,
+                                    12,
+                                    13,
+                                    14,
+                                    15
+                                  ]
+                                },
+                                {
+                                  pins: [
+                                    16,
+                                    17,
+                                    18,
+                                    19,
+                                    20,
+                                    21,
+                                    22,
+                                    23
+                                  ]
+                                },
+                                {
+                                  pins: [
+                                    24,
+                                    25,
+                                    26,
+                                    27,
+                                    28,
+                                    29,
+                                    30,
+                                    31
+                                  ]
+                                }
+                              ]
+                            },
+                            {
+                              lanes: [
+                                {
+                                  pins: [
+                                    0,
+                                    1,
+                                    2,
+                                    3,
+                                    4,
+                                    5,
+                                    6,
+                                    7
+                                  ]
+                                },
+                                {
+                                  pins: [
+                                    8,
+                                    9,
+                                    10,
+                                    11,
+                                    12,
+                                    13,
+                                    14,
+                                    15
+                                  ]
+                                },
+                                {
+                                  pins: [
+                                    16,
+                                    17,
+                                    18,
+                                    19,
+                                    20,
+                                    21,
+                                    22,
+                                    23
+                                  ]
+                                },
+                                {
+                                  pins: [
+                                    24,
+                                    25,
+                                    26,
+                                    27,
+                                    28,
+                                    29,
+                                    30,
+                                    31
+                                  ]
+                                },
+                                {
+                                  pins: [
+                                    0,
+                                    1,
+                                    2,
+                                    3,
+                                    4,
+                                    5,
+                                    6,
+                                    7
+                                  ]
+                                },
+                                {
+                                  pins: [
+                                    8,
+                                    9,
+                                    10,
+                                    11,
+                                    12,
+                                    13,
+                                    14,
+                                    15
+                                  ]
+                                },
+                                {
+                                  pins: [
+                                    16,
+                                    17,
+                                    18,
+                                    19,
+                                    20,
+                                    21,
+                                    22,
+                                    23
+                                  ]
+                                },
+                                {
+                                  pins: [
+                                    24,
+                                    25,
+                                    26,
+                                    27,
+                                    28,
+                                    29,
+                                    30,
+                                    31
+                                  ]
+                                }
+                              ]
+                            },
+                            {
+                              lanes: [
+                                {
+                                  pins: [
+                                    0,
+                                    1,
+                                    2,
+                                    3,
+                                    4,
+                                    5,
+                                    6,
+                                    7
+                                  ]
+                                },
+                                {
+                                  pins: [
+                                    8,
+                                    9,
+                                    10,
+                                    11,
+                                    12,
+                                    13,
+                                    14,
+                                    15
+                                  ]
+                                },
+                                {
+                                  pins: [
+                                    16,
+                                    17,
+                                    18,
+                                    19,
+                                    20,
+                                    21,
+                                    22,
+                                    23
+                                  ]
+                                },
+                                {
+                                  pins: [
+                                    24,
+                                    25,
+                                    26,
+                                    27,
+                                    28,
+                                    29,
+                                    30,
+                                    31
+                                  ]
+                                },
+                                {
+                                  pins: [
+                                    0,
+                                    1,
+                                    2,
+                                    3,
+                                    4,
+                                    5,
+                                    6,
+                                    7
+                                  ]
+                                },
+                                {
+                                  pins: [
+                                    8,
+                                    9,
+                                    10,
+                                    11,
+                                    12,
+                                    13,
+                                    14,
+                                    15
+                                  ]
+                                },
+                                {
+                                  pins: [
+                                    16,
+                                    17,
+                                    18,
+                                    19,
+                                    20,
+                                    21,
+                                    22,
+                                    23
+                                  ]
+                                },
+                                {
+                                  pins: [
+                                    24,
+                                    25,
+                                    26,
+                                    27,
+                                    28,
+                                    29,
+                                    30,
+                                    31
+                                  ]
+                                }
+                              ]
+                            },
+                            {
+                              lanes: [
+                                {
+                                  pins: [
+                                    0,
+                                    1,
+                                    2,
+                                    3,
+                                    4,
+                                    5,
+                                    6,
+                                    7
+                                  ]
+                                },
+                                {
+                                  pins: [
+                                    8,
+                                    9,
+                                    10,
+                                    11,
+                                    12,
+                                    13,
+                                    14,
+                                    15
+                                  ]
+                                },
+                                {
+                                  pins: [
+                                    16,
+                                    17,
+                                    18,
+                                    19,
+                                    20,
+                                    21,
+                                    22,
+                                    23
+                                  ]
+                                },
+                                {
+                                  pins: [
+                                    24,
+                                    25,
+                                    26,
+                                    27,
+                                    28,
+                                    29,
+                                    30,
+                                    31
+                                  ]
+                                },
+                                {
+                                  pins: [
+                                    0,
+                                    1,
+                                    2,
+                                    3,
+                                    4,
+                                    5,
+                                    6,
+                                    7
+                                  ]
+                                },
+                                {
+                                  pins: [
+                                    8,
+                                    9,
+                                    10,
+                                    11,
+                                    12,
+                                    13,
+                                    14,
+                                    15
+                                  ]
+                                },
+                                {
+                                  pins: [
+                                    16,
+                                    17,
+                                    18,
+                                    19,
+                                    20,
+                                    21,
+                                    22,
+                                    23
+                                  ]
+                                },
+                                {
+                                  pins: [
+                                    24,
+                                    25,
+                                    26,
+                                    27,
+                                    28,
+                                    29,
+                                    30,
+                                    31
+                                  ]
+                                }
+                              ]
+                            },
+                            {
+                              lanes: [
+                                {
+                                  pins: [
+                                    0,
+                                    1,
+                                    2,
+                                    3,
+                                    4,
+                                    5,
+                                    6,
+                                    7
+                                  ]
+                                },
+                                {
+                                  pins: [
+                                    8,
+                                    9,
+                                    10,
+                                    11,
+                                    12,
+                                    13,
+                                    14,
+                                    15
+                                  ]
+                                },
+                                {
+                                  pins: [
+                                    16,
+                                    17,
+                                    18,
+                                    19,
+                                    20,
+                                    21,
+                                    22,
+                                    23
+                                  ]
+                                },
+                                {
+                                  pins: [
+                                    24,
+                                    25,
+                                    26,
+                                    27,
+                                    28,
+                                    29,
+                                    30,
+                                    31
+                                  ]
+                                },
+                                {
+                                  pins: [
+                                    0,
+                                    1,
+                                    2,
+                                    3,
+                                    4,
+                                    5,
+                                    6,
+                                    7
+                                  ]
+                                },
+                                {
+                                  pins: [
+                                    8,
+                                    9,
+                                    10,
+                                    11,
+                                    12,
+                                    13,
+                                    14,
+                                    15
+                                  ]
+                                },
+                                {
+                                  pins: [
+                                    16,
+                                    17,
+                                    18,
+                                    19,
+                                    20,
+                                    21,
+                                    22,
+                                    23
+                                  ]
+                                },
+                                {
+                                  pins: [
+                                    24,
+                                    25,
+                                    26,
+                                    27,
+                                    28,
+                                    29,
+                                    30,
+                                    31
+                                  ]
+                                }
+                              ]
+                            },
+                            {
+                              lanes: [
+                                {
+                                  pins: [
+                                    0,
+                                    1,
+                                    2,
+                                    3,
+                                    4,
+                                    5,
+                                    6,
+                                    7
+                                  ]
+                                },
+                                {
+                                  pins: [
+                                    8,
+                                    9,
+                                    10,
+                                    11,
+                                    12,
+                                    13,
+                                    14,
+                                    15
+                                  ]
+                                },
+                                {
+                                  pins: [
+                                    16,
+                                    17,
+                                    18,
+                                    19,
+                                    20,
+                                    21,
+                                    22,
+                                    23
+                                  ]
+                                },
+                                {
+                                  pins: [
+                                    24,
+                                    25,
+                                    26,
+                                    27,
+                                    28,
+                                    29,
+                                    30,
+                                    31
+                                  ]
+                                },
+                                {
+                                  pins: [
+                                    0,
+                                    1,
+                                    2,
+                                    3,
+                                    4,
+                                    5,
+                                    6,
+                                    7
+                                  ]
+                                },
+                                {
+                                  pins: [
+                                    8,
+                                    9,
+                                    10,
+                                    11,
+                                    12,
+                                    13,
+                                    14,
+                                    15
+                                  ]
+                                },
+                                {
+                                  pins: [
+                                    16,
+                                    17,
+                                    18,
+                                    19,
+                                    20,
+                                    21,
+                                    22,
+                                    23
+                                  ]
+                                },
+                                {
+                                  pins: [
+                                    24,
+                                    25,
+                                    26,
+                                    27,
+                                    28,
+                                    29,
+                                    30,
+                                    31
+                                  ]
+                                }
+                              ]
+                            },
+                            {
+                              lanes: [
+                                {
+                                  pins: [
+                                    0,
+                                    1,
+                                    2,
+                                    3,
+                                    4,
+                                    5,
+                                    6,
+                                    7
+                                  ]
+                                },
+                                {
+                                  pins: [
+                                    8,
+                                    9,
+                                    10,
+                                    11,
+                                    12,
+                                    13,
+                                    14,
+                                    15
+                                  ]
+                                },
+                                {
+                                  pins: [
+                                    16,
+                                    17,
+                                    18,
+                                    19,
+                                    20,
+                                    21,
+                                    22,
+                                    23
+                                  ]
+                                },
+                                {
+                                  pins: [
+                                    24,
+                                    25,
+                                    26,
+                                    27,
+                                    28,
+                                    29,
+                                    30,
+                                    31
+                                  ]
+                                },
+                                {
+                                  pins: [
+                                    0,
+                                    1,
+                                    2,
+                                    3,
+                                    4,
+                                    5,
+                                    6,
+                                    7
+                                  ]
+                                },
+                                {
+                                  pins: [
+                                    8,
+                                    9,
+                                    10,
+                                    11,
+                                    12,
+                                    13,
+                                    14,
+                                    15
+                                  ]
+                                },
+                                {
+                                  pins: [
+                                    16,
+                                    17,
+                                    18,
+                                    19,
+                                    20,
+                                    21,
+                                    22,
+                                    23
+                                  ]
+                                },
+                                {
+                                  pins: [
+                                    24,
+                                    25,
+                                    26,
+                                    27,
+                                    28,
+                                    29,
+                                    30,
+                                    31
+                                  ]
+                                }
+                              ]
+                            },
+                            {
+                              lanes: [
+                                {
+                                  pins: [
+                                    0,
+                                    1,
+                                    2,
+                                    3,
+                                    4,
+                                    5,
+                                    6,
+                                    7
+                                  ]
+                                },
+                                {
+                                  pins: [
+                                    8,
+                                    9,
+                                    10,
+                                    11,
+                                    12,
+                                    13,
+                                    14,
+                                    15
+                                  ]
+                                },
+                                {
+                                  pins: [
+                                    16,
+                                    17,
+                                    18,
+                                    19,
+                                    20,
+                                    21,
+                                    22,
+                                    23
+                                  ]
+                                },
+                                {
+                                  pins: [
+                                    24,
+                                    25,
+                                    26,
+                                    27,
+                                    28,
+                                    29,
+                                    30,
+                                    31
+                                  ]
+                                },
+                                {
+                                  pins: [
+                                    0,
+                                    1,
+                                    2,
+                                    3,
+                                    4,
+                                    5,
+                                    6,
+                                    7
+                                  ]
+                                },
+                                {
+                                  pins: [
+                                    8,
+                                    9,
+                                    10,
+                                    11,
+                                    12,
+                                    13,
+                                    14,
+                                    15
+                                  ]
+                                },
+                                {
+                                  pins: [
+                                    16,
+                                    17,
+                                    18,
+                                    19,
+                                    20,
+                                    21,
+                                    22,
+                                    23
+                                  ]
+                                },
+                                {
+                                  pins: [
+                                    24,
+                                    25,
+                                    26,
+                                    27,
+                                    28,
+                                    29,
+                                    30,
+                                    31
+                                  ]
+                                }
+                              ]
+                            },
+                            {
+                              lanes: [
+                                {
+                                  pins: [
+                                    0,
+                                    1,
+                                    2,
+                                    3,
+                                    4,
+                                    5,
+                                    6,
+                                    7
+                                  ]
+                                },
+                                {
+                                  pins: [
+                                    8,
+                                    9,
+                                    10,
+                                    11,
+                                    12,
+                                    13,
+                                    14,
+                                    15
+                                  ]
+                                },
+                                {
+                                  pins: [
+                                    16,
+                                    17,
+                                    18,
+                                    19,
+                                    20,
+                                    21,
+                                    22,
+                                    23
+                                  ]
+                                },
+                                {
+                                  pins: [
+                                    24,
+                                    25,
+                                    26,
+                                    27,
+                                    28,
+                                    29,
+                                    30,
+                                    31
+                                  ]
+                                },
+                                {
+                                  pins: [
+                                    0,
+                                    1,
+                                    2,
+                                    3,
+                                    4,
+                                    5,
+                                    6,
+                                    7
+                                  ]
+                                },
+                                {
+                                  pins: [
+                                    8,
+                                    9,
+                                    10,
+                                    11,
+                                    12,
+                                    13,
+                                    14,
+                                    15
+                                  ]
+                                },
+                                {
+                                  pins: [
+                                    16,
+                                    17,
+                                    18,
+                                    19,
+                                    20,
+                                    21,
+                                    22,
+                                    23
+                                  ]
+                                },
+                                {
+                                  pins: [
+                                    24,
+                                    25,
+                                    26,
+                                    27,
+                                    28,
+                                    29,
+                                    30,
+                                    31
+                                  ]
+                                }
+                              ]
+                            },
+                            {
+                              lanes: [
+                                {
+                                  pins: [
+                                    0,
+                                    1,
+                                    2,
+                                    3,
+                                    4,
+                                    5,
+                                    6,
+                                    7
+                                  ]
+                                },
+                                {
+                                  pins: [
+                                    8,
+                                    9,
+                                    10,
+                                    11,
+                                    12,
+                                    13,
+                                    14,
+                                    15
+                                  ]
+                                },
+                                {
+                                  pins: [
+                                    16,
+                                    17,
+                                    18,
+                                    19,
+                                    20,
+                                    21,
+                                    22,
+                                    23
+                                  ]
+                                },
+                                {
+                                  pins: [
+                                    24,
+                                    25,
+                                    26,
+                                    27,
+                                    28,
+                                    29,
+                                    30,
+                                    31
+                                  ]
+                                },
+                                {
+                                  pins: [
+                                    0,
+                                    1,
+                                    2,
+                                    3,
+                                    4,
+                                    5,
+                                    6,
+                                    7
+                                  ]
+                                },
+                                {
+                                  pins: [
+                                    8,
+                                    9,
+                                    10,
+                                    11,
+                                    12,
+                                    13,
+                                    14,
+                                    15
+                                  ]
+                                },
+                                {
+                                  pins: [
+                                    16,
+                                    17,
+                                    18,
+                                    19,
+                                    20,
+                                    21,
+                                    22,
+                                    23
+                                  ]
+                                },
+                                {
+                                  pins: [
+                                    24,
+                                    25,
+                                    26,
+                                    27,
+                                    28,
+                                    29,
+                                    30,
+                                    31
+                                  ]
+                                }
+                              ]
+                            },
+                            {
+                              lanes: [
+                                {
+                                  pins: [
+                                    0,
+                                    1,
+                                    2,
+                                    3,
+                                    4,
+                                    5,
+                                    6,
+                                    7
+                                  ]
+                                },
+                                {
+                                  pins: [
+                                    8,
+                                    9,
+                                    10,
+                                    11,
+                                    12,
+                                    13,
+                                    14,
+                                    15
+                                  ]
+                                },
+                                {
+                                  pins: [
+                                    16,
+                                    17,
+                                    18,
+                                    19,
+                                    20,
+                                    21,
+                                    22,
+                                    23
+                                  ]
+                                },
+                                {
+                                  pins: [
+                                    24,
+                                    25,
+                                    26,
+                                    27,
+                                    28,
+                                    29,
+                                    30,
+                                    31
+                                  ]
+                                },
+                                {
+                                  pins: [
+                                    0,
+                                    1,
+                                    2,
+                                    3,
+                                    4,
+                                    5,
+                                    6,
+                                    7
+                                  ]
+                                },
+                                {
+                                  pins: [
+                                    8,
+                                    9,
+                                    10,
+                                    11,
+                                    12,
+                                    13,
+                                    14,
+                                    15
+                                  ]
+                                },
+                                {
+                                  pins: [
+                                    16,
+                                    17,
+                                    18,
+                                    19,
+                                    20,
+                                    21,
+                                    22,
+                                    23
+                                  ]
+                                },
+                                {
+                                  pins: [
+                                    24,
+                                    25,
+                                    26,
+                                    27,
+                                    28,
+                                    29,
+                                    30,
+                                    31
+                                  ]
+                                }
+                              ]
+                            }
+                          ]
+                        },
+                        {
+                          header: {
+                            group_id: 5892,
+                            entry_id: 54,
+                            instance_id: 0,
+                            context_type: "Struct",
+                            context_format: "Raw",
+                            unit_size: 0,
+                            priority_mask: {
+                              normal: true
+                            },
+                            key_size: 0,
+                            key_pos: 0,
+                            board_instance_mask: 65535
+                          },
+                          Ddr5CaPinMapElement: [
+                            {
+                              lanes: [
+                                {
+                                  pins: [
+                                    0,
+                                    1,
+                                    2,
+                                    3,
+                                    4,
+                                    5,
+                                    6,
+                                    7,
+                                    8,
+                                    9,
+                                    10,
+                                    11,
+                                    12,
+                                    13
+                                  ]
+                                },
+                                {
+                                  pins: [
+                                    0,
+                                    1,
+                                    2,
+                                    3,
+                                    4,
+                                    5,
+                                    6,
+                                    7,
+                                    8,
+                                    9,
+                                    10,
+                                    11,
+                                    12,
+                                    13
+                                  ]
+                                }
+                              ]
+                            },
+                            {
+                              lanes: [
+                                {
+                                  pins: [
+                                    0,
+                                    1,
+                                    2,
+                                    3,
+                                    4,
+                                    5,
+                                    6,
+                                    7,
+                                    8,
+                                    9,
+                                    10,
+                                    11,
+                                    12,
+                                    13
+                                  ]
+                                },
+                                {
+                                  pins: [
+                                    0,
+                                    1,
+                                    2,
+                                    3,
+                                    4,
+                                    5,
+                                    6,
+                                    7,
+                                    8,
+                                    9,
+                                    10,
+                                    11,
+                                    12,
+                                    13
+                                  ]
+                                }
+                              ]
+                            },
+                            {
+                              lanes: [
+                                {
+                                  pins: [
+                                    0,
+                                    1,
+                                    2,
+                                    3,
+                                    4,
+                                    5,
+                                    6,
+                                    7,
+                                    8,
+                                    9,
+                                    10,
+                                    11,
+                                    12,
+                                    13
+                                  ]
+                                },
+                                {
+                                  pins: [
+                                    0,
+                                    1,
+                                    2,
+                                    3,
+                                    4,
+                                    5,
+                                    6,
+                                    7,
+                                    8,
+                                    9,
+                                    10,
+                                    11,
+                                    12,
+                                    13
+                                  ]
+                                }
+                              ]
+                            },
+                            {
+                              lanes: [
+                                {
+                                  pins: [
+                                    0,
+                                    1,
+                                    2,
+                                    3,
+                                    4,
+                                    5,
+                                    6,
+                                    7,
+                                    8,
+                                    9,
+                                    10,
+                                    11,
+                                    12,
+                                    13
+                                  ]
+                                },
+                                {
+                                  pins: [
+                                    0,
+                                    1,
+                                    2,
+                                    3,
+                                    4,
+                                    5,
+                                    6,
+                                    7,
+                                    8,
+                                    9,
+                                    10,
+                                    11,
+                                    12,
+                                    13
+                                  ]
+                                }
+                              ]
+                            },
+                            {
+                              lanes: [
+                                {
+                                  pins: [
+                                    0,
+                                    1,
+                                    2,
+                                    3,
+                                    4,
+                                    5,
+                                    6,
+                                    7,
+                                    8,
+                                    9,
+                                    10,
+                                    11,
+                                    12,
+                                    13
+                                  ]
+                                },
+                                {
+                                  pins: [
+                                    0,
+                                    1,
+                                    2,
+                                    3,
+                                    4,
+                                    5,
+                                    6,
+                                    7,
+                                    8,
+                                    9,
+                                    10,
+                                    11,
+                                    12,
+                                    13
+                                  ]
+                                }
+                              ]
+                            },
+                            {
+                              lanes: [
+                                {
+                                  pins: [
+                                    0,
+                                    1,
+                                    2,
+                                    3,
+                                    4,
+                                    5,
+                                    6,
+                                    7,
+                                    8,
+                                    9,
+                                    10,
+                                    11,
+                                    12,
+                                    13
+                                  ]
+                                },
+                                {
+                                  pins: [
+                                    0,
+                                    1,
+                                    2,
+                                    3,
+                                    4,
+                                    5,
+                                    6,
+                                    7,
+                                    8,
+                                    9,
+                                    10,
+                                    11,
+                                    12,
+                                    13
+                                  ]
+                                }
+                              ]
+                            },
+                            {
+                              lanes: [
+                                {
+                                  pins: [
+                                    0,
+                                    1,
+                                    2,
+                                    3,
+                                    4,
+                                    5,
+                                    6,
+                                    7,
+                                    8,
+                                    9,
+                                    10,
+                                    11,
+                                    12,
+                                    13
+                                  ]
+                                },
+                                {
+                                  pins: [
+                                    0,
+                                    1,
+                                    2,
+                                    3,
+                                    4,
+                                    5,
+                                    6,
+                                    7,
+                                    8,
+                                    9,
+                                    10,
+                                    11,
+                                    12,
+                                    13
+                                  ]
+                                }
+                              ]
+                            },
+                            {
+                              lanes: [
+                                {
+                                  pins: [
+                                    0,
+                                    1,
+                                    2,
+                                    3,
+                                    4,
+                                    5,
+                                    6,
+                                    7,
+                                    8,
+                                    9,
+                                    10,
+                                    11,
+                                    12,
+                                    13
+                                  ]
+                                },
+                                {
+                                  pins: [
+                                    0,
+                                    1,
+                                    2,
+                                    3,
+                                    4,
+                                    5,
+                                    6,
+                                    7,
+                                    8,
+                                    9,
+                                    10,
+                                    11,
+                                    12,
+                                    13
+                                  ]
+                                }
+                              ]
+                            },
+                            {
+                              lanes: [
+                                {
+                                  pins: [
+                                    0,
+                                    1,
+                                    2,
+                                    3,
+                                    4,
+                                    5,
+                                    6,
+                                    7,
+                                    8,
+                                    9,
+                                    10,
+                                    11,
+                                    12,
+                                    13
+                                  ]
+                                },
+                                {
+                                  pins: [
+                                    0,
+                                    1,
+                                    2,
+                                    3,
+                                    4,
+                                    5,
+                                    6,
+                                    7,
+                                    8,
+                                    9,
+                                    10,
+                                    11,
+                                    12,
+                                    13
+                                  ]
+                                }
+                              ]
+                            },
+                            {
+                              lanes: [
+                                {
+                                  pins: [
+                                    0,
+                                    1,
+                                    2,
+                                    3,
+                                    4,
+                                    5,
+                                    6,
+                                    7,
+                                    8,
+                                    9,
+                                    10,
+                                    11,
+                                    12,
+                                    13
+                                  ]
+                                },
+                                {
+                                  pins: [
+                                    0,
+                                    1,
+                                    2,
+                                    3,
+                                    4,
+                                    5,
+                                    6,
+                                    7,
+                                    8,
+                                    9,
+                                    10,
+                                    11,
+                                    12,
+                                    13
+                                  ]
+                                }
+                              ]
+                            },
+                            {
+                              lanes: [
+                                {
+                                  pins: [
+                                    0,
+                                    1,
+                                    2,
+                                    3,
+                                    4,
+                                    5,
+                                    6,
+                                    7,
+                                    8,
+                                    9,
+                                    10,
+                                    11,
+                                    12,
+                                    13
+                                  ]
+                                },
+                                {
+                                  pins: [
+                                    0,
+                                    1,
+                                    2,
+                                    3,
+                                    4,
+                                    5,
+                                    6,
+                                    7,
+                                    8,
+                                    9,
+                                    10,
+                                    11,
+                                    12,
+                                    13
+                                  ]
+                                }
+                              ]
+                            },
+                            {
+                              lanes: [
+                                {
+                                  pins: [
+                                    0,
+                                    1,
+                                    2,
+                                    3,
+                                    4,
+                                    5,
+                                    6,
+                                    7,
+                                    8,
+                                    9,
+                                    10,
+                                    11,
+                                    12,
+                                    13
+                                  ]
+                                },
+                                {
+                                  pins: [
+                                    0,
+                                    1,
+                                    2,
+                                    3,
+                                    4,
+                                    5,
+                                    6,
+                                    7,
+                                    8,
+                                    9,
+                                    10,
+                                    11,
+                                    12,
+                                    13
+                                  ]
+                                }
+                              ]
+                            }
+                          ]
+                        },
+                        {
+                          header: {
+                            group_id: 5892,
+                            entry_id: 55,
+                            instance_id: 0,
+                            context_type: "Struct",
+                            context_format: "Raw",
+                            unit_size: 0,
+                            priority_mask: {
+                              normal: true
+                            },
+                            key_size: 0,
+                            key_pos: 0,
+                            board_instance_mask: 1
+                          },
+                          MemDfeSearchElement36: [
+                            {
+                              header: {
+                                total_size: 12,
+                                dimm_slots_per_channel: 2,
+                                dimm0_rank_bitmap: 1,
+                                dimm1_rank_bitmap: 2,
+                                sdram_io_width_bitmap: 255
+                              },
+                              payload: {
+                                total_size: 12,
+                                tx_dfe_tap_1_start: 224,
+                                tx_dfe_tap_1_end: 0,
+                                tx_dfe_tap_2_start: 241,
+                                tx_dfe_tap_2_end: 0,
+                                tx_dfe_tap_3_start: 0,
+                                tx_dfe_tap_3_end: 0,
+                                tx_dfe_tap_4_start: 0,
+                                tx_dfe_tap_4_end: 0
+                              },
+                              payload_ext: {
+                                total_size: 12,
+                                rx_dfe_tap_2_min_mv: 0,
+                                rx_dfe_tap_2_max_mv: 24,
+                                rx_dfe_tap_3_min_mv: 0,
+                                rx_dfe_tap_3_max_mv: 0,
+                                rx_dfe_tap_4_min_mv: 0,
+                                rx_dfe_tap_4_max_mv: 0,
+                              }
+                            },
+                            {
+                              header: {
+                                total_size: 12,
+                                dimm_slots_per_channel: 2,
+                                dimm0_rank_bitmap: 1,
+                                dimm1_rank_bitmap: 4,
+                                sdram_io_width_bitmap: 255
+                              },
+                              payload: {
+                                total_size: 12,
+                                tx_dfe_tap_1_start: 224,
+                                tx_dfe_tap_1_end: 0,
+                                tx_dfe_tap_2_start: 241,
+                                tx_dfe_tap_2_end: 0,
+                                tx_dfe_tap_3_start: 0,
+                                tx_dfe_tap_3_end: 0,
+                                tx_dfe_tap_4_start: 0,
+                                tx_dfe_tap_4_end: 0
+                              },
+                              payload_ext: {
+                                total_size: 12,
+                                rx_dfe_tap_2_min_mv: 0,
+                                rx_dfe_tap_2_max_mv: 24,
+                                rx_dfe_tap_3_min_mv: 0,
+                                rx_dfe_tap_3_max_mv: 0,
+                                rx_dfe_tap_4_min_mv: 0,
+                                rx_dfe_tap_4_max_mv: 0,
+                              }
+                            },
+                            {
+                              header: {
+                                total_size: 12,
+                                dimm_slots_per_channel: 2,
+                                dimm0_rank_bitmap: 2,
+                                dimm1_rank_bitmap: 1,
+                                sdram_io_width_bitmap: 255
+                              },
+                              payload: {
+                                total_size: 12,
+                                tx_dfe_tap_1_start: 224,
+                                tx_dfe_tap_1_end: 0,
+                                tx_dfe_tap_2_start: 241,
+                                tx_dfe_tap_2_end: 0,
+                                tx_dfe_tap_3_start: 0,
+                                tx_dfe_tap_3_end: 0,
+                                tx_dfe_tap_4_start: 0,
+                                tx_dfe_tap_4_end: 0
+                              },
+                              payload_ext: {
+                                total_size: 12,
+                                rx_dfe_tap_2_min_mv: 0,
+                                rx_dfe_tap_2_max_mv: 24,
+                                rx_dfe_tap_3_min_mv: 0,
+                                rx_dfe_tap_3_max_mv: 0,
+                                rx_dfe_tap_4_min_mv: 0,
+                                rx_dfe_tap_4_max_mv: 0,
+                              }
+                            },
+                            {
+                              header: {
+                                total_size: 12,
+                                dimm_slots_per_channel: 2,
+                                dimm0_rank_bitmap: 4,
+                                dimm1_rank_bitmap: 1,
+                                sdram_io_width_bitmap: 255
+                              },
+                              payload: {
+                                total_size: 12,
+                                tx_dfe_tap_1_start: 224,
+                                tx_dfe_tap_1_end: 0,
+                                tx_dfe_tap_2_start: 241,
+                                tx_dfe_tap_2_end: 0,
+                                tx_dfe_tap_3_start: 0,
+                                tx_dfe_tap_3_end: 0,
+                                tx_dfe_tap_4_start: 0,
+                                tx_dfe_tap_4_end: 0
+                              },
+                              payload_ext: {
+                                total_size: 12,
+                                rx_dfe_tap_2_min_mv: 0,
+                                rx_dfe_tap_2_max_mv: 24,
+                                rx_dfe_tap_3_min_mv: 0,
+                                rx_dfe_tap_3_max_mv: 0,
+                                rx_dfe_tap_4_min_mv: 0,
+                                rx_dfe_tap_4_max_mv: 0,
+                              }
+                            },
+                            {
+                              header: {
+                                total_size: 12,
+                                dimm_slots_per_channel: 2,
+                                dimm0_rank_bitmap: 2,
+                                dimm1_rank_bitmap: 2,
+                                sdram_io_width_bitmap: 255
+                              },
+                              payload: {
+                                total_size: 12,
+                                tx_dfe_tap_1_start: 224,
+                                tx_dfe_tap_1_end: 0,
+                                tx_dfe_tap_2_start: 241,
+                                tx_dfe_tap_2_end: 0,
+                                tx_dfe_tap_3_start: 0,
+                                tx_dfe_tap_3_end: 0,
+                                tx_dfe_tap_4_start: 0,
+                                tx_dfe_tap_4_end: 0
+                              },
+                              payload_ext: {
+                                total_size: 12,
+                                rx_dfe_tap_2_min_mv: 0,
+                                rx_dfe_tap_2_max_mv: 24,
+                                rx_dfe_tap_3_min_mv: 0,
+                                rx_dfe_tap_3_max_mv: 0,
+                                rx_dfe_tap_4_min_mv: 0,
+                                rx_dfe_tap_4_max_mv: 0,
+                              }
+                            },
+                            {
+                              header: {
+                                total_size: 12,
+                                dimm_slots_per_channel: 2,
+                                dimm0_rank_bitmap: 4,
+                                dimm1_rank_bitmap: 2,
+                                sdram_io_width_bitmap: 255
+                              },
+                              payload: {
+                                total_size: 12,
+                                tx_dfe_tap_1_start: 224,
+                                tx_dfe_tap_1_end: 0,
+                                tx_dfe_tap_2_start: 241,
+                                tx_dfe_tap_2_end: 0,
+                                tx_dfe_tap_3_start: 0,
+                                tx_dfe_tap_3_end: 0,
+                                tx_dfe_tap_4_start: 0,
+                                tx_dfe_tap_4_end: 0
+                              },
+                              payload_ext: {
+                                total_size: 12,
+                                rx_dfe_tap_2_min_mv: 0,
+                                rx_dfe_tap_2_max_mv: 24,
+                                rx_dfe_tap_3_min_mv: 0,
+                                rx_dfe_tap_3_max_mv: 0,
+                                rx_dfe_tap_4_min_mv: 0,
+                                rx_dfe_tap_4_max_mv: 0,
+                              }
+                            },
+                            {
+                              header: {
+                                total_size: 12,
+                                dimm_slots_per_channel: 2,
+                                dimm0_rank_bitmap: 2,
+                                dimm1_rank_bitmap: 4,
+                                sdram_io_width_bitmap: 255
+                              },
+                              payload: {
+                                total_size: 12,
+                                tx_dfe_tap_1_start: 224,
+                                tx_dfe_tap_1_end: 0,
+                                tx_dfe_tap_2_start: 241,
+                                tx_dfe_tap_2_end: 0,
+                                tx_dfe_tap_3_start: 0,
+                                tx_dfe_tap_3_end: 0,
+                                tx_dfe_tap_4_start: 0,
+                                tx_dfe_tap_4_end: 0
+                              },
+                              payload_ext: {
+                                total_size: 12,
+                                rx_dfe_tap_2_min_mv: 0,
+                                rx_dfe_tap_2_max_mv: 24,
+                                rx_dfe_tap_3_min_mv: 0,
+                                rx_dfe_tap_3_max_mv: 0,
+                                rx_dfe_tap_4_min_mv: 0,
+                                rx_dfe_tap_4_max_mv: 0,
+                              }
+                            },
+                            {
+                              header: {
+                                total_size: 12,
+                                dimm_slots_per_channel: 2,
+                                dimm0_rank_bitmap: 4,
+                                dimm1_rank_bitmap: 4,
+                                sdram_io_width_bitmap: 255
+                              },
+                              payload: {
+                                total_size: 12,
+                                tx_dfe_tap_1_start: 224,
+                                tx_dfe_tap_1_end: 0,
+                                tx_dfe_tap_2_start: 241,
+                                tx_dfe_tap_2_end: 0,
+                                tx_dfe_tap_3_start: 0,
+                                tx_dfe_tap_3_end: 0,
+                                tx_dfe_tap_4_start: 0,
+                                tx_dfe_tap_4_end: 0
+                              },
+                              payload_ext: {
+                                total_size: 12,
+                                rx_dfe_tap_2_min_mv: 0,
+                                rx_dfe_tap_2_max_mv: 24,
+                                rx_dfe_tap_3_min_mv: 0,
+                                rx_dfe_tap_3_max_mv: 0,
+                                rx_dfe_tap_4_min_mv: 0,
+                                rx_dfe_tap_4_max_mv: 0,
+                              }
+                            }
+                          ]
+                        },
+                        {
+                          header: {
+                            group_id: 5892,
+                            entry_id: 55,
+                            instance_id: 0,
+                            context_type: "Struct",
+                            context_format: "Raw",
+                            unit_size: 0,
+                            priority_mask: {
+                              normal: true
+                            },
+                            key_size: 0,
+                            key_pos: 0,
+                            board_instance_mask: 65535
+                          },
+                          MemDfeSearchElement36: [
+                            {
+                              header: {
+                                total_size: 12,
+                                dimm_slots_per_channel: 1,
+                                dimm0_rank_bitmap: 2,
+                                dimm1_rank_bitmap: 1,
+                                sdram_io_width_bitmap: 255
+                              },
+                              payload: {
+                                total_size: 12,
+                                tx_dfe_tap_1_start: 224,
+                                tx_dfe_tap_1_end: 0,
+                                tx_dfe_tap_2_start: 241,
+                                tx_dfe_tap_2_end: 0,
+                                tx_dfe_tap_3_start: 0,
+                                tx_dfe_tap_3_end: 0,
+                                tx_dfe_tap_4_start: 0,
+                                tx_dfe_tap_4_end: 0
+                              },
+                              payload_ext: {
+                                total_size: 12,
+                                rx_dfe_tap_2_min_mv: 0,
+                                rx_dfe_tap_2_max_mv: 24,
+                                rx_dfe_tap_3_min_mv: 0,
+                                rx_dfe_tap_3_max_mv: 0,
+                                rx_dfe_tap_4_min_mv: 0,
+                                rx_dfe_tap_4_max_mv: 0
+                              }
+                            },
+                            {
+                              header: {
+                                total_size: 12,
+                                dimm_slots_per_channel: 1,
+                                dimm0_rank_bitmap: 4,
+                                dimm1_rank_bitmap: 1,
+                                sdram_io_width_bitmap: 255
+                              },
+                              payload: {
+                                total_size: 12,
+                                tx_dfe_tap_1_start: 224,
+                                tx_dfe_tap_1_end: 0,
+                                tx_dfe_tap_2_start: 241,
+                                tx_dfe_tap_2_end: 0,
+                                tx_dfe_tap_3_start: 0,
+                                tx_dfe_tap_3_end: 0,
+                                tx_dfe_tap_4_start: 0,
+                                tx_dfe_tap_4_end: 0
+                              },
+                              payload_ext: {
+                                total_size: 12,
+                                rx_dfe_tap_2_min_mv: 0,
+                                rx_dfe_tap_2_max_mv: 24,
+                                rx_dfe_tap_3_min_mv: 0,
+                                rx_dfe_tap_3_max_mv: 0,
+                                rx_dfe_tap_4_min_mv: 0,
+                                rx_dfe_tap_4_max_mv: 0
+                              }
+                            }
+                          ]
+                        },
+                        {
+                          header: {
+                            group_id: 5892,
+                            entry_id: 64,
+                            instance_id: 0,
+                            context_type: "Struct",
+                            context_format: "Raw",
+                            unit_size: 0,
+                            priority_mask: {
+                              normal: true
+                            },
+                            key_size: 0,
+                            key_pos: 0,
+                            board_instance_mask: 1
+                          },
+                          platform_specific_overrides: [
+                            {
+                              MaxDimmsPerChannel6: {
+                                sockets: {
+                                  socket_0: true,
+                                  socket_1: true,
+                                  socket_2: true,
+                                  socket_3: true,
+                                  socket_4: true,
+                                  socket_5: true,
+                                  socket_6: true,
+                                  socket_7: true
+                                },
+                                channels: {
+                                  a: true,
+                                  b: true,
+                                  c: true,
+                                  d: true,
+                                  e: true,
+                                  f: true,
+                                  g: true,
+                                  h: true,
+                                  i: true,
+                                  j: true,
+                                  k: true,
+                                  l: true
+                                },
+                                dimms: "Any",
+                                value: 2,
+                              }
+                            },
+                            {
+                              MaxChannelsPerSocket: {
+                                sockets: {
+                                  socket_0: true,
+                                  socket_1: true,
+                                  socket_2: true,
+                                  socket_3: true,
+                                  socket_4: true,
+                                  socket_5: true,
+                                  socket_6: true,
+                                  socket_7: true
+                                },
+                                channels: "Any",
+                                dimms: "Any",
+                                value: 12
+                              }
+                            },
+                            {
+                              Unknown: [
+                                0
+                              ]
+                            },
+                            {
+                              Unknown: [
+                                0
+                              ]
+                            }
+                          ]
+                        },
+                        {
+                          header: {
+                            group_id: 5892,
+                            entry_id: 64,
+                            instance_id: 0,
+                            context_type: "Struct",
+                            context_format: "Raw",
+                            unit_size: 0,
+                            priority_mask: {
+                              hard_force: false,
+                              high: false,
+                              medium: false,
+                              event_logging: false,
+                              low: false,
+                              normal: true
+                            },
+                            key_size: 0,
+                            key_pos: 0,
+                            board_instance_mask: 65535
+                          },
+                          platform_specific_overrides: [
+                            {
+                              MaxDimmsPerChannel6: {
+                                sockets: {
+                                  socket_0: true,
+                                  socket_1: true,
+                                  socket_2: true,
+                                  socket_3: true,
+                                  socket_4: true,
+                                  socket_5: true,
+                                  socket_6: true,
+                                  socket_7: true
+                                },
+                                channels: {
+                                  a: true,
+                                  b: true,
+                                  c: true,
+                                  d: true,
+                                  e: true,
+                                  f: true,
+                                  g: true,
+                                  h: true,
+                                  i: true,
+                                  j: true,
+                                  k: true,
+                                  l: true
+                                },
+                                dimms: "Any",
+                                value: 1,
+                              }
+                            },
+                            {
+                              MaxChannelsPerSocket: {
+                                sockets: {
+                                  socket_0: true,
+                                  socket_1: true,
+                                  socket_2: true,
+                                  socket_3: true,
+                                  socket_4: true,
+                                  socket_5: true,
+                                  socket_6: true,
+                                  socket_7: true
+                                },
+                                channels: "Any",
+                                dimms: "Any",
+                                value: 12
+                              }
+                            },
+                            {
+                              Unknown: [
+                                0
+                              ]
+                            },
+                            {
+                              Unknown: [
+                                0
+                              ]
+                            }
+                          ]
+                        },
+                        {
+                          header: {
+                            group_id: 5892,
+                            entry_id: 80,
+                            instance_id: 0,
+                            context_type: "Struct",
+                            context_format: "Raw",
+                            unit_size: 0,
+                            priority_mask: {
+                              normal: true
+                            },
+                            key_size: 0,
+                            key_pos: 0,
+                            board_instance_mask: 65535
+                          },
+                          ConsoleOutControl: {
+                            abl_console_out_control: {
+                              enable_console_logging: true,
+                              enable_mem_flow_logging: true,
+                              enable_mem_setreg_logging: true,
+                              enable_mem_getreg_logging: false,
+                              enable_mem_status_logging: true,
+                              enable_mem_pmu_logging: true,
+                              enable_mem_pmu_sram_read_logging: false,
+                              enable_mem_pmu_sram_write_logging: false,
+                              enable_mem_test_verbose_logging: false,
+                              enable_mem_basic_output_logging: true,
+                              abl_console_port: 128
+                            },
+                            abl_breakpoint_control: {
+                              enable_breakpoint: false,
+                              break_on_all_dies: false
+                            }
+                          }
+                        },
+                        {
+                          header: {
+                            group_id: 5892,
+                            entry_id: 82,
+                            instance_id: 0,
+                            context_type: "Struct",
+                            context_format: "Raw",
+                            unit_size: 0,
+                            priority_mask: {
+                              normal: true
+                            },
+                            key_size: 0,
+                            key_pos: 0,
+                            board_instance_mask: 65535
+                          },
+                          ErrorOutControl116: {
+                            enable_error_reporting: false,
+                            enable_error_reporting_gpio: false,
+                            enable_error_reporting_beep_codes: false,
+                            enable_using_handshake: false,
+                            input_port: 132,
+                            output_delay: 15000,
+                            output_port: 128,
+                            stop_on_first_fatal_error: false,
+                            input_port_size: "32 Bit",
+                            output_port_size: "32 Bit",
+                            input_port_type: "FchHtIo",
+                            output_port_type: "FchHtIo",
+                            clear_acknowledgement: false,
+                            error_reporting_gpio: {
+                              pin: 85,
+                              iomux_control: 1,
+                              bank_control: 192
+                            },
+                            beep_code_table: [
+                              {
+                                custom_error_type: "General",
+                                peak_map: 1,
+                                peak_attr: {
+                                  peak_count: 8,
+                                  pulse_width: 0,
+                                  repeat_count: 0
+                                }
+                              },
+                              {
+                                custom_error_type: "Memory",
+                                peak_map: 2,
+                                peak_attr: {
+                                  peak_count: 20,
+                                  pulse_width: 0,
+                                  repeat_count: 0
+                                }
+                              },
+                              {
+                                custom_error_type: "Df",
+                                peak_map: 3,
+                                peak_attr: {
+                                  peak_count: 20,
+                                  pulse_width: 0,
+                                  repeat_count: 0
+                                }
+                              },
+                              {
+                                custom_error_type: "Ccx",
+                                peak_map: 4,
+                                peak_attr: {
+                                  peak_count: 20,
+                                  pulse_width: 0,
+                                  repeat_count: 0
+                                }
+                              },
+                              {
+                                custom_error_type: "Gnb",
+                                peak_map: 5,
+                                peak_attr: {
+                                  peak_count: 20,
+                                  pulse_width: 0,
+                                  repeat_count: 0
+                                }
+                              },
+                              {
+                                custom_error_type: "Psp",
+                                peak_map: 6,
+                                peak_attr: {
+                                  peak_count: 20,
+                                  pulse_width: 0,
+                                  repeat_count: 0
+                                }
+                              },
+                              {
+                                custom_error_type: "Smu",
+                                peak_map: 7,
+                                peak_attr: {
+                                  peak_count: 20,
+                                  pulse_width: 0,
+                                  repeat_count: 0,
+                                }
+                              },
+                              {
+                                custom_error_type: "Unknown",
+                                peak_map: 2,
+                                peak_attr: {
+                                  peak_count: 4,
+                                  pulse_width: 0,
+                                  repeat_count: 0,
+                                }
+                              }
+                            ],
+                            enable_heart_beat: false,
+                            enable_power_good_gpio: false,
+                            power_good_gpio: {
+                              pin: 0,
+                              iomux_control: 0,
+                              bank_control: 0
+                            }
+                          }
+                        },
+                        {
+                          header: {
+                            group_id: 5892,
+                            entry_id: 83,
+                            instance_id: 0,
+                            context_type: "Struct",
+                            context_format: "Raw",
+                            unit_size: 0,
+                            priority_mask: {
+                              hard_force: false,
+                              high: false,
+                              medium: false,
+                              event_logging: false,
+                              low: false,
+                              normal: true,
+                            },
+                            key_size: 0,
+                            key_pos: 0,
+                            board_instance_mask: 65535
+                          },
+                          ExtVoltageControl: {
+                            enabled: true,
+                            input_port: 132,
+                            output_port: 128,
+                            input_port_size: "32 Bit",
+                            output_port_size: "32 Bit",
+                            input_port_type: "FchHtIo",
+                            output_port_type: "FchHtIo",
+                            clear_acknowledgement: false
+                          }
+                        },
+                        {
+                          header: {
+                            group_id: 5892,
+                            entry_id: 137,
+                            instance_id: 0,
+                            context_type: "Struct",
+                            context_format: "Raw",
+                            unit_size: 0,
+                            priority_mask: {
+                              hard_force: false,
+                              high: false,
+                              medium: false,
+                              event_logging: false,
+                              low: false,
+                              normal: true,
+                            },
+                            key_size: 0,
+                            key_pos: 0,
+                            board_instance_mask: 65535
+                          },
+                          RdimmDdr5BusElement: [
+                            {
+                              header: {
+                                total_size: 12,
+                                target_memclk: 2000,
+                                dimm_slots_per_channel: 2,
+                                dimm0_rank_bitmap: 4,
+                                dimm1_rank_bitmap: 4,
+                                sdram_io_width_bitmap: 255
+                              },
+                              payload: {
+                                total_size: 124,
+                                ca_timing_mode: 1,
+                                dimm0_rttnomwr: 240,
+                                dimm0_rttnomrd: 60,
+                                dimm0_rttwr: 240,
+                                dimm0_rttpack: 60,
+                                dimm0_dqs_rttpark: 60,
+                                dimm1_rttnomwr: 240,
+                                dimm1_rttnomrd: 60,
+                                dimm1_rttwr: 240,
+                                dimm1_rttpack: 60,
+                                dimm1_dqs_rttpark: 60,
+                                dram_drv: 34,
+                                ck_odt_a: 0,
+                                cs_odt_a: 0,
+                                ca_odt_a: 0,
+                                ck_odt_b: 40,
+                                cs_odt_b: 40,
+                                ca_odt_b: 60,
+                                p_odt: 60,
+                                dq_drv: 34,
+                                alert_pullup: 80,
+                                ca_drv: 40,
+                                phy_vref: 45,
+                                dq_vref: 45,
+                                ca_vref: 63,
+                                cs_vref: 56,
+                                d_ca_vref: 32,
+                                d_cs_vref: 40,
+                                rx_dfe: 1,
+                                tx_dfe: 1
+                              }
+                            },
+                            {
+                              header: {
+                                total_size: 12,
+                                target_memclk: 2200,
+                                dimm_slots_per_channel: 2,
+                                dimm0_rank_bitmap: 2,
+                                dimm1_rank_bitmap: 2,
+                                sdram_io_width_bitmap: 1
+                              },
+                              payload: {
+                                total_size: 124,
+                                ca_timing_mode: 1,
+                                dimm0_rttnomwr: 120,
+                                dimm0_rttnomrd: 34,
+                                dimm0_rttwr: 80,
+                                dimm0_rttpack: 34,
+                                dimm0_dqs_rttpark: 48,
+                                dimm1_rttnomwr: 120,
+                                dimm1_rttnomrd: 34,
+                                dimm1_rttwr: 80,
+                                dimm1_rttpack: 34,
+                                dimm1_dqs_rttpark: 48,
+                                dram_drv: 34,
+                                ck_odt_a: 0,
+                                cs_odt_a: 0,
+                                ca_odt_a: 0,
+                                ck_odt_b: 40,
+                                cs_odt_b: 40,
+                                ca_odt_b: 60,
+                                p_odt: 48,
+                                dq_drv: 34,
+                                alert_pullup: 80,
+                                ca_drv: 40,
+                                phy_vref: 45,
+                                dq_vref: 40,
+                                ca_vref: 63,
+                                cs_vref: 56,
+                                d_ca_vref: 32,
+                                d_cs_vref: 40,
+                                rx_dfe: 1,
+                                tx_dfe: 1
+                              }
+                            },
+                            {
+                              header: {
+                                total_size: 12,
+                                target_memclk: 2200,
+                                dimm_slots_per_channel: 2,
+                                dimm0_rank_bitmap: 2,
+                                dimm1_rank_bitmap: 2,
+                                sdram_io_width_bitmap: 2
+                              },
+                              payload: {
+                                total_size: 124,
+                                ca_timing_mode: 1,
+                                dimm0_rttnomwr: 120,
+                                dimm0_rttnomrd: 34,
+                                dimm0_rttwr: 80,
+                                dimm0_rttpack: 34,
+                                dimm0_dqs_rttpark: 48,
+                                dimm1_rttnomwr: 120,
+                                dimm1_rttnomrd: 34,
+                                dimm1_rttwr: 80,
+                                dimm1_rttpack: 34,
+                                dimm1_dqs_rttpark: 48,
+                                dram_drv: 34,
+                                ck_odt_a: 0,
+                                cs_odt_a: 0,
+                                ca_odt_a: 240,
+                                ck_odt_b: 40,
+                                cs_odt_b: 40,
+                                ca_odt_b: 60,
+                                p_odt: 48,
+                                dq_drv: 34,
+                                alert_pullup: 80,
+                                ca_drv: 40,
+                                phy_vref: 45,
+                                dq_vref: 40,
+                                ca_vref: 63,
+                                cs_vref: 56,
+                                d_ca_vref: 32,
+                                d_cs_vref: 40,
+                                rx_dfe: 1,
+                                tx_dfe: 1
+                              }
+                            },
+                            {
+                              header: {
+                                total_size: 12,
+                                target_memclk: 2600,
+                                dimm_slots_per_channel: 2,
+                                dimm0_rank_bitmap: 1,
+                                dimm1_rank_bitmap: 4,
+                                sdram_io_width_bitmap: 255
+                              },
+                              payload: {
+                                total_size: 124,
+                                ca_timing_mode: 1,
+                                dimm0_rttnomwr: 0,
+                                dimm0_rttnomrd: 0,
+                                dimm0_rttwr: 0,
+                                dimm0_rttpack: 0,
+                                dimm0_dqs_rttpark: 0,
+                                dimm1_rttnomwr: 0,
+                                dimm1_rttnomrd: 60,
+                                dimm1_rttwr: 120,
+                                dimm1_rttpack: 60,
+                                dimm1_dqs_rttpark: 60,
+                                dram_drv: 34,
+                                ck_odt_a: 0,
+                                cs_odt_a: 0,
+                                ca_odt_a: 0,
+                                ck_odt_b: 40,
+                                cs_odt_b: 40,
+                                ca_odt_b: 60,
+                                p_odt: 60,
+                                dq_drv: 34,
+                                alert_pullup: 80,
+                                ca_drv: 40,
+                                phy_vref: 45,
+                                dq_vref: 45,
+                                ca_vref: 63,
+                                cs_vref: 56,
+                                d_ca_vref: 48,
+                                d_cs_vref: 58,
+                                rx_dfe: 1,
+                                tx_dfe: 1
+                              }
+                            },
+                            {
+                              header: {
+                                total_size: 12,
+                                target_memclk: 3200,
+                                dimm_slots_per_channel: 1,
+                                dimm0_rank_bitmap: 2,
+                                dimm1_rank_bitmap: 1,
+                                sdram_io_width_bitmap: 1
+                              },
+                              payload: {
+                                total_size: 124,
+                                ca_timing_mode: 1,
+                                dimm0_rttnomwr: 0,
+                                dimm0_rttnomrd: 60,
+                                dimm0_rttwr: 48,
+                                dimm0_rttpack: 60,
+                                dimm0_dqs_rttpark: 60,
+                                dimm1_rttnomwr: 0,
+                                dimm1_rttnomrd: 0,
+                                dimm1_rttwr: 0,
+                                dimm1_rttpack: 0,
+                                dimm1_dqs_rttpark: 0,
+                                dram_drv: 34,
+                                ck_odt_a: 0,
+                                cs_odt_a: 0,
+                                ca_odt_a: 0,
+                                ck_odt_b: 40,
+                                cs_odt_b: 40,
+                                ca_odt_b: 60,
+                                p_odt: 60,
+                                dq_drv: 40,
+                                alert_pullup: 80,
+                                ca_drv: 40,
+                                phy_vref: 93,
+                                dq_vref: 40,
+                                ca_vref: 63,
+                                cs_vref: 56,
+                                d_ca_vref: 48,
+                                d_cs_vref: 58,
+                                rx_dfe: 1,
+                                tx_dfe: 1
+                              }
+                            },
+                            {
+                              header: {
+                                total_size: 12,
+                                target_memclk: 3200,
+                                dimm_slots_per_channel: 1,
+                                dimm0_rank_bitmap: 2,
+                                dimm1_rank_bitmap: 1,
+                                sdram_io_width_bitmap: 2
+                              },
+                              payload: {
+                                total_size: 124,
+                                ca_timing_mode: 1,
+                                dimm0_rttnomwr: 0,
+                                dimm0_rttnomrd: 60,
+                                dimm0_rttwr: 48,
+                                dimm0_rttpack: 60,
+                                dimm0_dqs_rttpark: 60,
+                                dimm1_rttnomwr: 0,
+                                dimm1_rttnomrd: 0,
+                                dimm1_rttwr: 0,
+                                dimm1_rttpack: 0,
+                                dimm1_dqs_rttpark: 0,
+                                dram_drv: 34,
+                                ck_odt_a: 0,
+                                cs_odt_a: 0,
+                                ca_odt_a: 240,
+                                ck_odt_b: 40,
+                                cs_odt_b: 40,
+                                ca_odt_b: 60,
+                                p_odt: 60,
+                                dq_drv: 40,
+                                alert_pullup: 80,
+                                ca_drv: 40,
+                                phy_vref: 93,
+                                dq_vref: 40,
+                                ca_vref: 63,
+                                cs_vref: 56,
+                                d_ca_vref: 48,
+                                d_cs_vref: 58,
+                                rx_dfe: 1,
+                                tx_dfe: 1
+                              }
+                            },
+                            {
+                              header: {
+                                total_size: 12,
+                                target_memclk: 3200,
+                                dimm_slots_per_channel: 1,
+                                dimm0_rank_bitmap: 4,
+                                dimm1_rank_bitmap: 1,
+                                sdram_io_width_bitmap: 255
+                              },
+                              payload: {
+                                total_size: 124,
+                                ca_timing_mode: 1,
+                                dimm0_rttnomwr: 0,
+                                dimm0_rttnomrd: 60,
+                                dimm0_rttwr: 120,
+                                dimm0_rttpack: 60,
+                                dimm0_dqs_rttpark: 60,
+                                dimm1_rttnomwr: 0,
+                                dimm1_rttnomrd: 0,
+                                dimm1_rttwr: 0,
+                                dimm1_rttpack: 0,
+                                dimm1_dqs_rttpark: 0,
+                                dram_drv: 34,
+                                ck_odt_a: 0,
+                                cs_odt_a: 0,
+                                ca_odt_a: 0,
+                                ck_odt_b: 40,
+                                cs_odt_b: 40,
+                                ca_odt_b: 60,
+                                p_odt: 60,
+                                dq_drv: 40,
+                                alert_pullup: 80,
+                                ca_drv: 40,
+                                phy_vref: 45,
+                                dq_vref: 45,
+                                ca_vref: 63,
+                                cs_vref: 56,
+                                d_ca_vref: 48,
+                                d_cs_vref: 58,
+                                rx_dfe: 1,
+                                tx_dfe: 1
+                              }
+                            },
+                            {
+                              header: {
+                                total_size: 12,
+                                target_memclk: 2600,
+                                dimm_slots_per_channel: 2,
+                                dimm0_rank_bitmap: 1,
+                                dimm1_rank_bitmap: 2,
+                                sdram_io_width_bitmap: 1
+                              },
+                              payload: {
+                                total_size: 124,
+                                ca_timing_mode: 1,
+                                dimm0_rttnomwr: 0,
+                                dimm0_rttnomrd: 0,
+                                dimm0_rttwr: 0,
+                                dimm0_rttpack: 0,
+                                dimm0_dqs_rttpark: 0,
+                                dimm1_rttnomwr: 0,
+                                dimm1_rttnomrd: 60,
+                                dimm1_rttwr: 48,
+                                dimm1_rttpack: 60,
+                                dimm1_dqs_rttpark: 60,
+                                dram_drv: 34,
+                                ck_odt_a: 0,
+                                cs_odt_a: 0,
+                                ca_odt_a: 0,
+                                ck_odt_b: 40,
+                                cs_odt_b: 40,
+                                ca_odt_b: 60,
+                                p_odt: 60,
+                                dq_drv: 34,
+                                alert_pullup: 80,
+                                ca_drv: 40,
+                                phy_vref: 93,
+                                dq_vref: 40,
+                                ca_vref: 63,
+                                cs_vref: 56,
+                                d_ca_vref: 48,
+                                d_cs_vref: 58,
+                                rx_dfe: 1,
+                                tx_dfe: 1
+                              }
+                            },
+                            {
+                              header: {
+                                total_size: 12,
+                                target_memclk: 2600,
+                                dimm_slots_per_channel: 2,
+                                dimm0_rank_bitmap: 1,
+                                dimm1_rank_bitmap: 2,
+                                sdram_io_width_bitmap: 2
+                              },
+                              payload: {
+                                total_size: 124,
+                                ca_timing_mode: 1,
+                                dimm0_rttnomwr: 0,
+                                dimm0_rttnomrd: 0,
+                                dimm0_rttwr: 0,
+                                dimm0_rttpack: 0,
+                                dimm0_dqs_rttpark: 0,
+                                dimm1_rttnomwr: 0,
+                                dimm1_rttnomrd: 60,
+                                dimm1_rttwr: 48,
+                                dimm1_rttpack: 60,
+                                dimm1_dqs_rttpark: 60,
+                                dram_drv: 34,
+                                ck_odt_a: 0,
+                                cs_odt_a: 0,
+                                ca_odt_a: 240,
+                                ck_odt_b: 40,
+                                cs_odt_b: 40,
+                                ca_odt_b: 60,
+                                p_odt: 60,
+                                dq_drv: 34,
+                                alert_pullup: 80,
+                                ca_drv: 40,
+                                phy_vref: 93,
+                                dq_vref: 40,
+                                ca_vref: 63,
+                                cs_vref: 56,
+                                d_ca_vref: 48,
+                                d_cs_vref: 58,
+                                rx_dfe: 1,
+                                tx_dfe: 1
+                              }
+                            }
+                          ]
+                        },
+                        {
+                          header: {
+                            group_id: 5892,
+                            entry_id: 137,
+                            instance_id: 11392,
+                            context_type: "Struct",
+                            context_format: "Raw",
+                            unit_size: 0,
+                            priority_mask: {
+                              hard_force: false,
+                              high: false,
+                              medium: false,
+                              event_logging: false,
+                              low: false,
+                              normal: true,
+                            },
+                            key_size: 0,
+                            key_pos: 0,
+                            board_instance_mask: 65535
+                          },
+                          RdimmDdr5BusElement: [
+                            {
+                              header: {
+                                total_size: 12,
+                                target_memclk: 1800,
+                                dimm_slots_per_channel: 2,
+                                dimm0_rank_bitmap: 4,
+                                dimm1_rank_bitmap: 4,
+                                sdram_io_width_bitmap: 255
+                              },
+                              payload: {
+                                total_size: 124,
+                                ca_timing_mode: 1,
+                                dimm0_rttnomwr: 240,
+                                dimm0_rttnomrd: 60,
+                                dimm0_rttwr: 240,
+                                dimm0_rttpack: 60,
+                                dimm0_dqs_rttpark: 60,
+                                dimm1_rttnomwr: 240,
+                                dimm1_rttnomrd: 60,
+                                dimm1_rttwr: 240,
+                                dimm1_rttpack: 60,
+                                dimm1_dqs_rttpark: 60,
+                                dram_drv: 34,
+                                ck_odt_a: 0,
+                                cs_odt_a: 0,
+                                ca_odt_a: 0,
+                                ck_odt_b: 40,
+                                cs_odt_b: 40,
+                                ca_odt_b: 60,
+                                p_odt: 60,
+                                dq_drv: 34,
+                                alert_pullup: 80,
+                                ca_drv: 40,
+                                phy_vref: 45,
+                                dq_vref: 45,
+                                ca_vref: 63,
+                                cs_vref: 56,
+                                d_ca_vref: 32,
+                                d_cs_vref: 40,
+                                rx_dfe: 1,
+                                tx_dfe: 1
+                              }
+                            },
+                            {
+                              header: {
+                                total_size: 12,
+                                target_memclk: 2000,
+                                dimm_slots_per_channel: 2,
+                                dimm0_rank_bitmap: 4,
+                                dimm1_rank_bitmap: 4,
+                                sdram_io_width_bitmap: 255
+                              },
+                              payload: {
+                                total_size: 124,
+                                ca_timing_mode: 1,
+                                dimm0_rttnomwr: 240,
+                                dimm0_rttnomrd: 48,
+                                dimm0_rttwr: 120,
+                                dimm0_rttpack: 48,
+                                dimm0_dqs_rttpark: 60,
+                                dimm1_rttnomwr: 240,
+                                dimm1_rttnomrd: 48,
+                                dimm1_rttwr: 120,
+                                dimm1_rttpack: 48,
+                                dimm1_dqs_rttpark: 60,
+                                dram_drv: 34,
+                                ck_odt_a: 0,
+                                cs_odt_a: 0,
+                                ca_odt_a: 0,
+                                ck_odt_b: 40,
+                                cs_odt_b: 40,
+                                ca_odt_b: 60,
+                                p_odt: 60,
+                                dq_drv: 34,
+                                alert_pullup: 80,
+                                ca_drv: 40,
+                                phy_vref: 45,
+                                dq_vref: 45,
+                                ca_vref: 63,
+                                cs_vref: 56,
+                                d_ca_vref: 32,
+                                d_cs_vref: 40,
+                                rx_dfe: 1,
+                                tx_dfe: 1
+                              }
+                            },
+                            {
+                              header: {
+                                total_size: 12,
+                                target_memclk: 2200,
+                                dimm_slots_per_channel: 2,
+                                dimm0_rank_bitmap: 4,
+                                dimm1_rank_bitmap: 4,
+                                sdram_io_width_bitmap: 1
+                              },
+                              payload: {
+                                total_size: 124,
+                                ca_timing_mode: 1,
+                                dimm0_rttnomwr: 120,
+                                dimm0_rttnomrd: 120,
+                                dimm0_rttwr: 240,
+                                dimm0_rttpack: 60,
+                                dimm0_dqs_rttpark: 60,
+                                dimm1_rttnomwr: 120,
+                                dimm1_rttnomrd: 120,
+                                dimm1_rttwr: 240,
+                                dimm1_rttpack: 60,
+                                dimm1_dqs_rttpark: 60,
+                                dram_drv: 34,
+                                ck_odt_a: 0,
+                                cs_odt_a: 0,
+                                ca_odt_a: 0,
+                                ck_odt_b: 40,
+                                cs_odt_b: 40,
+                                ca_odt_b: 60,
+                                p_odt: 60,
+                                dq_drv: 34,
+                                alert_pullup: 80,
+                                ca_drv: 40,
+                                phy_vref: 45,
+                                dq_vref: 45,
+                                ca_vref: 63,
+                                cs_vref: 56,
+                                d_ca_vref: 32,
+                                d_cs_vref: 40,
+                                rx_dfe: 1,
+                                tx_dfe: 1
+                              }
+                            },
+                            {
+                              header: {
+                                total_size: 12,
+                                target_memclk: 2200,
+                                dimm_slots_per_channel: 2,
+                                dimm0_rank_bitmap: 2,
+                                dimm1_rank_bitmap: 2,
+                                sdram_io_width_bitmap: 1
+                              },
+                              payload: {
+                                total_size: 124,
+                                ca_timing_mode: 1,
+                                dimm0_rttnomwr: 120,
+                                dimm0_rttnomrd: 34,
+                                dimm0_rttwr: 80,
+                                dimm0_rttpack: 34,
+                                dimm0_dqs_rttpark: 48,
+                                dimm1_rttnomwr: 120,
+                                dimm1_rttnomrd: 34,
+                                dimm1_rttwr: 80,
+                                dimm1_rttpack: 34,
+                                dimm1_dqs_rttpark: 48,
+                                dram_drv: 34,
+                                ck_odt_a: 0,
+                                cs_odt_a: 0,
+                                ca_odt_a: 0,
+                                ck_odt_b: 40,
+                                cs_odt_b: 40,
+                                ca_odt_b: 60,
+                                p_odt: 48,
+                                dq_drv: 34,
+                                alert_pullup: 80,
+                                ca_drv: 40,
+                                phy_vref: 45,
+                                dq_vref: 40,
+                                ca_vref: 63,
+                                cs_vref: 56,
+                                d_ca_vref: 32,
+                                d_cs_vref: 40,
+                                rx_dfe: 1,
+                                tx_dfe: 1
+                              }
+                            },
+                            {
+                              header: {
+                                total_size: 12,
+                                target_memclk: 2200,
+                                dimm_slots_per_channel: 2,
+                                dimm0_rank_bitmap: 2,
+                                dimm1_rank_bitmap: 2,
+                                sdram_io_width_bitmap: 2
+                              },
+                              payload: {
+                                total_size: 124,
+                                ca_timing_mode: 1,
+                                dimm0_rttnomwr: 120,
+                                dimm0_rttnomrd: 34,
+                                dimm0_rttwr: 80,
+                                dimm0_rttpack: 34,
+                                dimm0_dqs_rttpark: 48,
+                                dimm1_rttnomwr: 120,
+                                dimm1_rttnomrd: 34,
+                                dimm1_rttwr: 80,
+                                dimm1_rttpack: 34,
+                                dimm1_dqs_rttpark: 48,
+                                dram_drv: 34,
+                                ck_odt_a: 0,
+                                cs_odt_a: 0,
+                                ca_odt_a: 240,
+                                ck_odt_b: 40,
+                                cs_odt_b: 40,
+                                ca_odt_b: 60,
+                                p_odt: 48,
+                                dq_drv: 34,
+                                alert_pullup: 80,
+                                ca_drv: 40,
+                                phy_vref: 45,
+                                dq_vref: 40,
+                                ca_vref: 63,
+                                cs_vref: 56,
+                                d_ca_vref: 32,
+                                d_cs_vref: 40,
+                                rx_dfe: 1,
+                                tx_dfe: 1
+                              }
+                            },
+                            {
+                              header: {
+                                total_size: 12,
+                                target_memclk: 2600,
+                                dimm_slots_per_channel: 2,
+                                dimm0_rank_bitmap: 1,
+                                dimm1_rank_bitmap: 4,
+                                sdram_io_width_bitmap: 255
+                              },
+                              payload: {
+                                total_size: 124,
+                                ca_timing_mode: 1,
+                                dimm0_rttnomwr: 0,
+                                dimm0_rttnomrd: 0,
+                                dimm0_rttwr: 0,
+                                dimm0_rttpack: 0,
+                                dimm0_dqs_rttpark: 0,
+                                dimm1_rttnomwr: 0,
+                                dimm1_rttnomrd: 48,
+                                dimm1_rttwr: 240,
+                                dimm1_rttpack: 48,
+                                dimm1_dqs_rttpark: 60,
+                                dram_drv: 34,
+                                ck_odt_a: 0,
+                                cs_odt_a: 0,
+                                ca_odt_a: 0,
+                                ck_odt_b: 40,
+                                cs_odt_b: 40,
+                                ca_odt_b: 60,
+                                p_odt: 60,
+                                dq_drv: 34,
+                                alert_pullup: 80,
+                                ca_drv: 40,
+                                phy_vref: 45,
+                                dq_vref: 45,
+                                ca_vref: 63,
+                                cs_vref: 56,
+                                d_ca_vref: 48,
+                                d_cs_vref: 58,
+                                rx_dfe: 1,
+                                tx_dfe: 1
+                              }
+                            },
+                            {
+                              header: {
+                                total_size: 12,
+                                target_memclk: 3200,
+                                dimm_slots_per_channel: 1,
+                                dimm0_rank_bitmap: 2,
+                                dimm1_rank_bitmap: 1,
+                                sdram_io_width_bitmap: 1
+                              },
+                              payload: {
+                                total_size: 124,
+                                ca_timing_mode: 1,
+                                dimm0_rttnomwr: 0,
+                                dimm0_rttnomrd: 60,
+                                dimm0_rttwr: 60,
+                                dimm0_rttpack: 60,
+                                dimm0_dqs_rttpark: 60,
+                                dimm1_rttnomwr: 0,
+                                dimm1_rttnomrd: 0,
+                                dimm1_rttwr: 0,
+                                dimm1_rttpack: 0,
+                                dimm1_dqs_rttpark: 0,
+                                dram_drv: 34,
+                                ck_odt_a: 0,
+                                cs_odt_a: 0,
+                                ca_odt_a: 0,
+                                ck_odt_b: 40,
+                                cs_odt_b: 40,
+                                ca_odt_b: 60,
+                                p_odt: 48,
+                                dq_drv: 40,
+                                alert_pullup: 80,
+                                ca_drv: 40,
+                                phy_vref: 93,
+                                dq_vref: 40,
+                                ca_vref: 63,
+                                cs_vref: 56,
+                                d_ca_vref: 48,
+                                d_cs_vref: 58,
+                                rx_dfe: 1,
+                                tx_dfe: 1
+                              }
+                            },
+                            {
+                              header: {
+                                total_size: 12,
+                                target_memclk: 3200,
+                                dimm_slots_per_channel: 1,
+                                dimm0_rank_bitmap: 2,
+                                dimm1_rank_bitmap: 1,
+                                sdram_io_width_bitmap: 2
+                              },
+                              payload: {
+                                total_size: 124,
+                                ca_timing_mode: 1,
+                                dimm0_rttnomwr: 0,
+                                dimm0_rttnomrd: 60,
+                                dimm0_rttwr: 60,
+                                dimm0_rttpack: 60,
+                                dimm0_dqs_rttpark: 60,
+                                dimm1_rttnomwr: 0,
+                                dimm1_rttnomrd: 0,
+                                dimm1_rttwr: 0,
+                                dimm1_rttpack: 0,
+                                dimm1_dqs_rttpark: 0,
+                                dram_drv: 34,
+                                ck_odt_a: 0,
+                                cs_odt_a: 0,
+                                ca_odt_a: 240,
+                                ck_odt_b: 40,
+                                cs_odt_b: 40,
+                                ca_odt_b: 60,
+                                p_odt: 48,
+                                dq_drv: 40,
+                                alert_pullup: 80,
+                                ca_drv: 40,
+                                phy_vref: 93,
+                                dq_vref: 40,
+                                ca_vref: 63,
+                                cs_vref: 56,
+                                d_ca_vref: 48,
+                                d_cs_vref: 58,
+                                rx_dfe: 1,
+                                tx_dfe: 1
+                              }
+                            },
+                            {
+                              header: {
+                                total_size: 12,
+                                target_memclk: 3200,
+                                dimm_slots_per_channel: 1,
+                                dimm0_rank_bitmap: 4,
+                                dimm1_rank_bitmap: 1,
+                                sdram_io_width_bitmap: 255
+                              },
+                              payload: {
+                                total_size: 124,
+                                ca_timing_mode: 1,
+                                dimm0_rttnomwr: 0,
+                                dimm0_rttnomrd: 60,
+                                dimm0_rttwr: 120,
+                                dimm0_rttpack: 60,
+                                dimm0_dqs_rttpark: 60,
+                                dimm1_rttnomwr: 0,
+                                dimm1_rttnomrd: 0,
+                                dimm1_rttwr: 0,
+                                dimm1_rttpack: 0,
+                                dimm1_dqs_rttpark: 0,
+                                dram_drv: 34,
+                                ck_odt_a: 0,
+                                cs_odt_a: 0,
+                                ca_odt_a: 0,
+                                ck_odt_b: 40,
+                                cs_odt_b: 40,
+                                ca_odt_b: 60,
+                                p_odt: 60,
+                                dq_drv: 40,
+                                alert_pullup: 80,
+                                ca_drv: 40,
+                                phy_vref: 45,
+                                dq_vref: 45,
+                                ca_vref: 63,
+                                cs_vref: 56,
+                                d_ca_vref: 48,
+                                d_cs_vref: 58,
+                                rx_dfe: 1,
+                                tx_dfe: 1
+                              }
+                            },
+                            {
+                              header: {
+                                total_size: 12,
+                                target_memclk: 2600,
+                                dimm_slots_per_channel: 2,
+                                dimm0_rank_bitmap: 1,
+                                dimm1_rank_bitmap: 2,
+                                sdram_io_width_bitmap: 1
+                              },
+                              payload: {
+                                total_size: 124,
+                                ca_timing_mode: 1,
+                                dimm0_rttnomwr: 0,
+                                dimm0_rttnomrd: 0,
+                                dimm0_rttwr: 0,
+                                dimm0_rttpack: 0,
+                                dimm0_dqs_rttpark: 0,
+                                dimm1_rttnomwr: 0,
+                                dimm1_rttnomrd: 60,
+                                dimm1_rttwr: 60,
+                                dimm1_rttpack: 60,
+                                dimm1_dqs_rttpark: 60,
+                                dram_drv: 34,
+                                ck_odt_a: 0,
+                                cs_odt_a: 0,
+                                ca_odt_a: 0,
+                                ck_odt_b: 40,
+                                cs_odt_b: 40,
+                                ca_odt_b: 60,
+                                p_odt: 48,
+                                dq_drv: 34,
+                                alert_pullup: 80,
+                                ca_drv: 40,
+                                phy_vref: 93,
+                                dq_vref: 40,
+                                ca_vref: 63,
+                                cs_vref: 56,
+                                d_ca_vref: 48,
+                                d_cs_vref: 58,
+                                rx_dfe: 1,
+                                tx_dfe: 1
+                              }
+                            },
+                            {
+                              header: {
+                                total_size: 12,
+                                target_memclk: 2600,
+                                dimm_slots_per_channel: 2,
+                                dimm0_rank_bitmap: 1,
+                                dimm1_rank_bitmap: 2,
+                                sdram_io_width_bitmap: 2
+                              },
+                              payload: {
+                                total_size: 124,
+                                ca_timing_mode: 1,
+                                dimm0_rttnomwr: 0,
+                                dimm0_rttnomrd: 0,
+                                dimm0_rttwr: 0,
+                                dimm0_rttpack: 0,
+                                dimm0_dqs_rttpark: 0,
+                                dimm1_rttnomwr: 0,
+                                dimm1_rttnomrd: 60,
+                                dimm1_rttwr: 60,
+                                dimm1_rttpack: 60,
+                                dimm1_dqs_rttpark: 60,
+                                dram_drv: 34,
+                                ck_odt_a: 0,
+                                cs_odt_a: 0,
+                                ca_odt_a: 240,
+                                ck_odt_b: 40,
+                                cs_odt_b: 40,
+                                ca_odt_b: 60,
+                                p_odt: 48,
+                                dq_drv: 34,
+                                alert_pullup: 80,
+                                ca_drv: 40,
+                                phy_vref: 93,
+                                dq_vref: 40,
+                                ca_vref: 63,
+                                cs_vref: 56,
+                                d_ca_vref: 48,
+                                d_cs_vref: 58,
+                                rx_dfe: 1,
+                                tx_dfe: 1
+                              }
+                            }
+                          ]
+                        },
+                        {
+                          header: {
+                            group_id: 5892,
+                            entry_id: 137,
+                            instance_id: 11396,
+                            context_type: "Struct",
+                            context_format: "Raw",
+                            unit_size: 0,
+                            priority_mask: {
+                              hard_force: false,
+                              high: false,
+                              medium: false,
+                              event_logging: false,
+                              low: false,
+                              normal: true,
+                            },
+                            key_size: 0,
+                            key_pos: 0,
+                            board_instance_mask: 65535
+                          },
+                          RdimmDdr5BusElement: [
+                            {
+                              header: {
+                                total_size: 12,
+                                target_memclk: 1800,
+                                dimm_slots_per_channel: 2,
+                                dimm0_rank_bitmap: 4,
+                                dimm1_rank_bitmap: 4,
+                                sdram_io_width_bitmap: 255
+                              },
+                              payload: {
+                                total_size: 124,
+                                ca_timing_mode: 1,
+                                dimm0_rttnomwr: 240,
+                                dimm0_rttnomrd: 60,
+                                dimm0_rttwr: 240,
+                                dimm0_rttpack: 60,
+                                dimm0_dqs_rttpark: 60,
+                                dimm1_rttnomwr: 240,
+                                dimm1_rttnomrd: 60,
+                                dimm1_rttwr: 240,
+                                dimm1_rttpack: 60,
+                                dimm1_dqs_rttpark: 60,
+                                dram_drv: 34,
+                                ck_odt_a: 0,
+                                cs_odt_a: 0,
+                                ca_odt_a: 0,
+                                ck_odt_b: 40,
+                                cs_odt_b: 40,
+                                ca_odt_b: 60,
+                                p_odt: 60,
+                                dq_drv: 34,
+                                alert_pullup: 80,
+                                ca_drv: 40,
+                                phy_vref: 45,
+                                dq_vref: 45,
+                                ca_vref: 63,
+                                cs_vref: 56,
+                                d_ca_vref: 32,
+                                d_cs_vref: 40,
+                                rx_dfe: 1,
+                                tx_dfe: 1
+                              }
+                            },
+                            {
+                              header: {
+                                total_size: 12,
+                                target_memclk: 2000,
+                                dimm_slots_per_channel: 2,
+                                dimm0_rank_bitmap: 4,
+                                dimm1_rank_bitmap: 4,
+                                sdram_io_width_bitmap: 255
+                              },
+                              payload: {
+                                total_size: 124,
+                                ca_timing_mode: 1,
+                                dimm0_rttnomwr: 240,
+                                dimm0_rttnomrd: 48,
+                                dimm0_rttwr: 120,
+                                dimm0_rttpack: 48,
+                                dimm0_dqs_rttpark: 60,
+                                dimm1_rttnomwr: 240,
+                                dimm1_rttnomrd: 48,
+                                dimm1_rttwr: 120,
+                                dimm1_rttpack: 48,
+                                dimm1_dqs_rttpark: 60,
+                                dram_drv: 34,
+                                ck_odt_a: 0,
+                                cs_odt_a: 0,
+                                ca_odt_a: 0,
+                                ck_odt_b: 40,
+                                cs_odt_b: 40,
+                                ca_odt_b: 60,
+                                p_odt: 60,
+                                dq_drv: 34,
+                                alert_pullup: 80,
+                                ca_drv: 40,
+                                phy_vref: 45,
+                                dq_vref: 45,
+                                ca_vref: 63,
+                                cs_vref: 56,
+                                d_ca_vref: 32,
+                                d_cs_vref: 40,
+                                rx_dfe: 1,
+                                tx_dfe: 1
+                              }
+                            },
+                            {
+                              header: {
+                                total_size: 12,
+                                target_memclk: 2200,
+                                dimm_slots_per_channel: 2,
+                                dimm0_rank_bitmap: 4,
+                                dimm1_rank_bitmap: 4,
+                                sdram_io_width_bitmap: 1
+                              },
+                              payload: {
+                                total_size: 124,
+                                ca_timing_mode: 1,
+                                dimm0_rttnomwr: 120,
+                                dimm0_rttnomrd: 120,
+                                dimm0_rttwr: 240,
+                                dimm0_rttpack: 60,
+                                dimm0_dqs_rttpark: 60,
+                                dimm1_rttnomwr: 120,
+                                dimm1_rttnomrd: 120,
+                                dimm1_rttwr: 240,
+                                dimm1_rttpack: 60,
+                                dimm1_dqs_rttpark: 60,
+                                dram_drv: 34,
+                                ck_odt_a: 0,
+                                cs_odt_a: 0,
+                                ca_odt_a: 0,
+                                ck_odt_b: 40,
+                                cs_odt_b: 40,
+                                ca_odt_b: 60,
+                                p_odt: 60,
+                                dq_drv: 34,
+                                alert_pullup: 80,
+                                ca_drv: 40,
+                                phy_vref: 45,
+                                dq_vref: 45,
+                                ca_vref: 63,
+                                cs_vref: 56,
+                                d_ca_vref: 32,
+                                d_cs_vref: 40,
+                                rx_dfe: 1,
+                                tx_dfe: 1
+                              }
+                            },
+                            {
+                              header: {
+                                total_size: 12,
+                                target_memclk: 2200,
+                                dimm_slots_per_channel: 2,
+                                dimm0_rank_bitmap: 2,
+                                dimm1_rank_bitmap: 2,
+                                sdram_io_width_bitmap: 1
+                              },
+                              payload: {
+                                total_size: 124,
+                                ca_timing_mode: 1,
+                                dimm0_rttnomwr: 120,
+                                dimm0_rttnomrd: 34,
+                                dimm0_rttwr: 80,
+                                dimm0_rttpack: 34,
+                                dimm0_dqs_rttpark: 48,
+                                dimm1_rttnomwr: 120,
+                                dimm1_rttnomrd: 34,
+                                dimm1_rttwr: 80,
+                                dimm1_rttpack: 34,
+                                dimm1_dqs_rttpark: 48,
+                                dram_drv: 34,
+                                ck_odt_a: 0,
+                                cs_odt_a: 0,
+                                ca_odt_a: 0,
+                                ck_odt_b: 40,
+                                cs_odt_b: 40,
+                                ca_odt_b: 60,
+                                p_odt: 48,
+                                dq_drv: 34,
+                                alert_pullup: 80,
+                                ca_drv: 40,
+                                phy_vref: 45,
+                                dq_vref: 40,
+                                ca_vref: 63,
+                                cs_vref: 56,
+                                d_ca_vref: 32,
+                                d_cs_vref: 40,
+                                rx_dfe: 1,
+                                tx_dfe: 1
+                              }
+                            },
+                            {
+                              header: {
+                                total_size: 12,
+                                target_memclk: 2200,
+                                dimm_slots_per_channel: 2,
+                                dimm0_rank_bitmap: 2,
+                                dimm1_rank_bitmap: 2,
+                                sdram_io_width_bitmap: 2
+                              },
+                              payload: {
+                                total_size: 124,
+                                ca_timing_mode: 1,
+                                dimm0_rttnomwr: 120,
+                                dimm0_rttnomrd: 34,
+                                dimm0_rttwr: 80,
+                                dimm0_rttpack: 34,
+                                dimm0_dqs_rttpark: 48,
+                                dimm1_rttnomwr: 120,
+                                dimm1_rttnomrd: 34,
+                                dimm1_rttwr: 80,
+                                dimm1_rttpack: 34,
+                                dimm1_dqs_rttpark: 48,
+                                dram_drv: 34,
+                                ck_odt_a: 0,
+                                cs_odt_a: 0,
+                                ca_odt_a: 240,
+                                ck_odt_b: 40,
+                                cs_odt_b: 40,
+                                ca_odt_b: 60,
+                                p_odt: 48,
+                                dq_drv: 34,
+                                alert_pullup: 80,
+                                ca_drv: 40,
+                                phy_vref: 45,
+                                dq_vref: 40,
+                                ca_vref: 63,
+                                cs_vref: 56,
+                                d_ca_vref: 32,
+                                d_cs_vref: 40,
+                                rx_dfe: 1,
+                                tx_dfe: 1
+                              }
+                            },
+                            {
+                              header: {
+                                total_size: 12,
+                                target_memclk: 2600,
+                                dimm_slots_per_channel: 2,
+                                dimm0_rank_bitmap: 1,
+                                dimm1_rank_bitmap: 4,
+                                sdram_io_width_bitmap: 255
+                              },
+                              payload: {
+                                total_size: 124,
+                                ca_timing_mode: 1,
+                                dimm0_rttnomwr: 0,
+                                dimm0_rttnomrd: 0,
+                                dimm0_rttwr: 0,
+                                dimm0_rttpack: 0,
+                                dimm0_dqs_rttpark: 0,
+                                dimm1_rttnomwr: 0,
+                                dimm1_rttnomrd: 48,
+                                dimm1_rttwr: 240,
+                                dimm1_rttpack: 48,
+                                dimm1_dqs_rttpark: 60,
+                                dram_drv: 34,
+                                ck_odt_a: 0,
+                                cs_odt_a: 0,
+                                ca_odt_a: 0,
+                                ck_odt_b: 40,
+                                cs_odt_b: 40,
+                                ca_odt_b: 60,
+                                p_odt: 60,
+                                dq_drv: 34,
+                                alert_pullup: 80,
+                                ca_drv: 40,
+                                phy_vref: 45,
+                                dq_vref: 45,
+                                ca_vref: 63,
+                                cs_vref: 56,
+                                d_ca_vref: 48,
+                                d_cs_vref: 58,
+                                rx_dfe: 1,
+                                tx_dfe: 1
+                              }
+                            },
+                            {
+                              header: {
+                                total_size: 12,
+                                target_memclk: 3200,
+                                dimm_slots_per_channel: 1,
+                                dimm0_rank_bitmap: 2,
+                                dimm1_rank_bitmap: 1,
+                                sdram_io_width_bitmap: 1
+                              },
+                              payload: {
+                                total_size: 124,
+                                ca_timing_mode: 1,
+                                dimm0_rttnomwr: 0,
+                                dimm0_rttnomrd: 60,
+                                dimm0_rttwr: 60,
+                                dimm0_rttpack: 60,
+                                dimm0_dqs_rttpark: 60,
+                                dimm1_rttnomwr: 0,
+                                dimm1_rttnomrd: 0,
+                                dimm1_rttwr: 0,
+                                dimm1_rttpack: 0,
+                                dimm1_dqs_rttpark: 0,
+                                dram_drv: 34,
+                                ck_odt_a: 0,
+                                cs_odt_a: 0,
+                                ca_odt_a: 0,
+                                ck_odt_b: 40,
+                                cs_odt_b: 40,
+                                ca_odt_b: 60,
+                                p_odt: 48,
+                                dq_drv: 34,
+                                alert_pullup: 80,
+                                ca_drv: 40,
+                                phy_vref: 93,
+                                dq_vref: 40,
+                                ca_vref: 63,
+                                cs_vref: 56,
+                                d_ca_vref: 48,
+                                d_cs_vref: 58,
+                                rx_dfe: 1,
+                                tx_dfe: 1
+                              }
+                            },
+                            {
+                              header: {
+                                total_size: 12,
+                                target_memclk: 3200,
+                                dimm_slots_per_channel: 1,
+                                dimm0_rank_bitmap: 2,
+                                dimm1_rank_bitmap: 1,
+                                sdram_io_width_bitmap: 2
+                              },
+                              payload: {
+                                total_size: 124,
+                                ca_timing_mode: 1,
+                                dimm0_rttnomwr: 0,
+                                dimm0_rttnomrd: 60,
+                                dimm0_rttwr: 60,
+                                dimm0_rttpack: 60,
+                                dimm0_dqs_rttpark: 60,
+                                dimm1_rttnomwr: 0,
+                                dimm1_rttnomrd: 0,
+                                dimm1_rttwr: 0,
+                                dimm1_rttpack: 0,
+                                dimm1_dqs_rttpark: 0,
+                                dram_drv: 34,
+                                ck_odt_a: 0,
+                                cs_odt_a: 0,
+                                ca_odt_a: 240,
+                                ck_odt_b: 40,
+                                cs_odt_b: 40,
+                                ca_odt_b: 60,
+                                p_odt: 48,
+                                dq_drv: 34,
+                                alert_pullup: 80,
+                                ca_drv: 40,
+                                phy_vref: 93,
+                                dq_vref: 40,
+                                ca_vref: 63,
+                                cs_vref: 56,
+                                d_ca_vref: 48,
+                                d_cs_vref: 58,
+                                rx_dfe: 1,
+                                tx_dfe: 1
+                              }
+                            },
+                            {
+                              header: {
+                                total_size: 12,
+                                target_memclk: 3200,
+                                dimm_slots_per_channel: 1,
+                                dimm0_rank_bitmap: 4,
+                                dimm1_rank_bitmap: 1,
+                                sdram_io_width_bitmap: 255
+                              },
+                              payload: {
+                                total_size: 124,
+                                ca_timing_mode: 1,
+                                dimm0_rttnomwr: 0,
+                                dimm0_rttnomrd: 60,
+                                dimm0_rttwr: 120,
+                                dimm0_rttpack: 60,
+                                dimm0_dqs_rttpark: 60,
+                                dimm1_rttnomwr: 0,
+                                dimm1_rttnomrd: 0,
+                                dimm1_rttwr: 0,
+                                dimm1_rttpack: 0,
+                                dimm1_dqs_rttpark: 0,
+                                dram_drv: 34,
+                                ck_odt_a: 0,
+                                cs_odt_a: 0,
+                                ca_odt_a: 0,
+                                ck_odt_b: 40,
+                                cs_odt_b: 40,
+                                ca_odt_b: 60,
+                                p_odt: 60,
+                                dq_drv: 34,
+                                alert_pullup: 80,
+                                ca_drv: 40,
+                                phy_vref: 45,
+                                dq_vref: 45,
+                                ca_vref: 63,
+                                cs_vref: 56,
+                                d_ca_vref: 48,
+                                d_cs_vref: 58,
+                                rx_dfe: 1,
+                                tx_dfe: 1
+                              }
+                            },
+                            {
+                              header: {
+                                total_size: 12,
+                                target_memclk: 2600,
+                                dimm_slots_per_channel: 2,
+                                dimm0_rank_bitmap: 1,
+                                dimm1_rank_bitmap: 2,
+                                sdram_io_width_bitmap: 1
+                              },
+                              payload: {
+                                total_size: 124,
+                                ca_timing_mode: 1,
+                                dimm0_rttnomwr: 0,
+                                dimm0_rttnomrd: 0,
+                                dimm0_rttwr: 0,
+                                dimm0_rttpack: 0,
+                                dimm0_dqs_rttpark: 0,
+                                dimm1_rttnomwr: 0,
+                                dimm1_rttnomrd: 60,
+                                dimm1_rttwr: 60,
+                                dimm1_rttpack: 60,
+                                dimm1_dqs_rttpark: 60,
+                                dram_drv: 34,
+                                ck_odt_a: 0,
+                                cs_odt_a: 0,
+                                ca_odt_a: 0,
+                                ck_odt_b: 40,
+                                cs_odt_b: 40,
+                                ca_odt_b: 60,
+                                p_odt: 48,
+                                dq_drv: 34,
+                                alert_pullup: 80,
+                                ca_drv: 40,
+                                phy_vref: 93,
+                                dq_vref: 40,
+                                ca_vref: 63,
+                                cs_vref: 56,
+                                d_ca_vref: 48,
+                                d_cs_vref: 58,
+                                rx_dfe: 1,
+                                tx_dfe: 1
+                              }
+                            },
+                            {
+                              header: {
+                                total_size: 12,
+                                target_memclk: 2600,
+                                dimm_slots_per_channel: 2,
+                                dimm0_rank_bitmap: 1,
+                                dimm1_rank_bitmap: 2,
+                                sdram_io_width_bitmap: 2
+                              },
+                              payload: {
+                                total_size: 124,
+                                ca_timing_mode: 1,
+                                dimm0_rttnomwr: 0,
+                                dimm0_rttnomrd: 0,
+                                dimm0_rttwr: 0,
+                                dimm0_rttpack: 0,
+                                dimm0_dqs_rttpark: 0,
+                                dimm1_rttnomwr: 0,
+                                dimm1_rttnomrd: 60,
+                                dimm1_rttwr: 60,
+                                dimm1_rttpack: 60,
+                                dimm1_dqs_rttpark: 60,
+                                dram_drv: 34,
+                                ck_odt_a: 0,
+                                cs_odt_a: 0,
+                                ca_odt_a: 240,
+                                ck_odt_b: 40,
+                                cs_odt_b: 40,
+                                ca_odt_b: 60,
+                                p_odt: 48,
+                                dq_drv: 34,
+                                alert_pullup: 80,
+                                ca_drv: 40,
+                                phy_vref: 93,
+                                dq_vref: 40,
+                                ca_vref: 63,
+                                cs_vref: 56,
+                                d_ca_vref: 48,
+                                d_cs_vref: 58,
+                                rx_dfe: 1,
+                                tx_dfe: 1
+                              }
+                            }
+                          ]
+                        },
+                        {
+                          header: {
+                            group_id: 5892,
+                            entry_id: 137,
+                            instance_id: 11398,
+                            context_type: "Struct",
+                            context_format: "Raw",
+                            unit_size: 0,
+                            priority_mask: {
+                              hard_force: false,
+                              high: false,
+                              medium: false,
+                              event_logging: false,
+                              low: false,
+                              normal: true,
+                            },
+                            key_size: 0,
+                            key_pos: 0,
+                            board_instance_mask: 65535
+                          },
+                          RdimmDdr5BusElement: [
+                            {
+                              header: {
+                                total_size: 12,
+                                target_memclk: 2000,
+                                dimm_slots_per_channel: 2,
+                                dimm0_rank_bitmap: 4,
+                                dimm1_rank_bitmap: 4,
+                                sdram_io_width_bitmap: 255
+                              },
+                              payload: {
+                                total_size: 124,
+                                ca_timing_mode: 1,
+                                dimm0_rttnomwr: 240,
+                                dimm0_rttnomrd: 60,
+                                dimm0_rttwr: 240,
+                                dimm0_rttpack: 60,
+                                dimm0_dqs_rttpark: 60,
+                                dimm1_rttnomwr: 240,
+                                dimm1_rttnomrd: 60,
+                                dimm1_rttwr: 240,
+                                dimm1_rttpack: 60,
+                                dimm1_dqs_rttpark: 60,
+                                dram_drv: 34,
+                                ck_odt_a: 0,
+                                cs_odt_a: 0,
+                                ca_odt_a: 0,
+                                ck_odt_b: 40,
+                                cs_odt_b: 40,
+                                ca_odt_b: 60,
+                                p_odt: 60,
+                                dq_drv: 34,
+                                alert_pullup: 80,
+                                ca_drv: 40,
+                                phy_vref: 45,
+                                dq_vref: 45,
+                                ca_vref: 63,
+                                cs_vref: 56,
+                                d_ca_vref: 32,
+                                d_cs_vref: 40,
+                                rx_dfe: 1,
+                                tx_dfe: 1
+                              }
+                            },
+                            {
+                              header: {
+                                total_size: 12,
+                                target_memclk: 2200,
+                                dimm_slots_per_channel: 2,
+                                dimm0_rank_bitmap: 4,
+                                dimm1_rank_bitmap: 4,
+                                sdram_io_width_bitmap: 1
+                              },
+                              payload: {
+                                total_size: 124,
+                                ca_timing_mode: 1,
+                                dimm0_rttnomwr: 120,
+                                dimm0_rttnomrd: 120,
+                                dimm0_rttwr: 240,
+                                dimm0_rttpack: 60,
+                                dimm0_dqs_rttpark: 60,
+                                dimm1_rttnomwr: 120,
+                                dimm1_rttnomrd: 120,
+                                dimm1_rttwr: 240,
+                                dimm1_rttpack: 60,
+                                dimm1_dqs_rttpark: 60,
+                                dram_drv: 34,
+                                ck_odt_a: 0,
+                                cs_odt_a: 0,
+                                ca_odt_a: 0,
+                                ck_odt_b: 40,
+                                cs_odt_b: 40,
+                                ca_odt_b: 60,
+                                p_odt: 60,
+                                dq_drv: 34,
+                                alert_pullup: 80,
+                                ca_drv: 40,
+                                phy_vref: 45,
+                                dq_vref: 45,
+                                ca_vref: 63,
+                                cs_vref: 56,
+                                d_ca_vref: 32,
+                                d_cs_vref: 40,
+                                rx_dfe: 1,
+                                tx_dfe: 1
+                              }
+                            },
+                            {
+                              header: {
+                                total_size: 12,
+                                target_memclk: 2200,
+                                dimm_slots_per_channel: 2,
+                                dimm0_rank_bitmap: 2,
+                                dimm1_rank_bitmap: 2,
+                                sdram_io_width_bitmap: 1
+                              },
+                              payload: {
+                                total_size: 124,
+                                ca_timing_mode: 1,
+                                dimm0_rttnomwr: 120,
+                                dimm0_rttnomrd: 34,
+                                dimm0_rttwr: 80,
+                                dimm0_rttpack: 34,
+                                dimm0_dqs_rttpark: 48,
+                                dimm1_rttnomwr: 120,
+                                dimm1_rttnomrd: 34,
+                                dimm1_rttwr: 80,
+                                dimm1_rttpack: 34,
+                                dimm1_dqs_rttpark: 48,
+                                dram_drv: 34,
+                                ck_odt_a: 0,
+                                cs_odt_a: 0,
+                                ca_odt_a: 0,
+                                ck_odt_b: 40,
+                                cs_odt_b: 40,
+                                ca_odt_b: 60,
+                                p_odt: 48,
+                                dq_drv: 34,
+                                alert_pullup: 80,
+                                ca_drv: 40,
+                                phy_vref: 45,
+                                dq_vref: 40,
+                                ca_vref: 63,
+                                cs_vref: 56,
+                                d_ca_vref: 32,
+                                d_cs_vref: 40,
+                                rx_dfe: 1,
+                                tx_dfe: 1
+                              }
+                            },
+                            {
+                              header: {
+                                total_size: 12,
+                                target_memclk: 2200,
+                                dimm_slots_per_channel: 2,
+                                dimm0_rank_bitmap: 2,
+                                dimm1_rank_bitmap: 2,
+                                sdram_io_width_bitmap: 2
+                              },
+                              payload: {
+                                total_size: 124,
+                                ca_timing_mode: 1,
+                                dimm0_rttnomwr: 120,
+                                dimm0_rttnomrd: 34,
+                                dimm0_rttwr: 80,
+                                dimm0_rttpack: 34,
+                                dimm0_dqs_rttpark: 48,
+                                dimm1_rttnomwr: 120,
+                                dimm1_rttnomrd: 34,
+                                dimm1_rttwr: 80,
+                                dimm1_rttpack: 34,
+                                dimm1_dqs_rttpark: 48,
+                                dram_drv: 34,
+                                ck_odt_a: 0,
+                                cs_odt_a: 0,
+                                ca_odt_a: 240,
+                                ck_odt_b: 40,
+                                cs_odt_b: 40,
+                                ca_odt_b: 60,
+                                p_odt: 48,
+                                dq_drv: 34,
+                                alert_pullup: 80,
+                                ca_drv: 40,
+                                phy_vref: 45,
+                                dq_vref: 40,
+                                ca_vref: 63,
+                                cs_vref: 56,
+                                d_ca_vref: 32,
+                                d_cs_vref: 40,
+                                rx_dfe: 1,
+                                tx_dfe: 1
+                              }
+                            },
+                            {
+                              header: {
+                                total_size: 12,
+                                target_memclk: 2600,
+                                dimm_slots_per_channel: 2,
+                                dimm0_rank_bitmap: 1,
+                                dimm1_rank_bitmap: 4,
+                                sdram_io_width_bitmap: 255
+                              },
+                              payload: {
+                                total_size: 124,
+                                ca_timing_mode: 1,
+                                dimm0_rttnomwr: 0,
+                                dimm0_rttnomrd: 0,
+                                dimm0_rttwr: 0,
+                                dimm0_rttpack: 0,
+                                dimm0_dqs_rttpark: 0,
+                                dimm1_rttnomwr: 0,
+                                dimm1_rttnomrd: 48,
+                                dimm1_rttwr: 240,
+                                dimm1_rttpack: 48,
+                                dimm1_dqs_rttpark: 60,
+                                dram_drv: 34,
+                                ck_odt_a: 0,
+                                cs_odt_a: 0,
+                                ca_odt_a: 0,
+                                ck_odt_b: 40,
+                                cs_odt_b: 40,
+                                ca_odt_b: 60,
+                                p_odt: 60,
+                                dq_drv: 34,
+                                alert_pullup: 80,
+                                ca_drv: 40,
+                                phy_vref: 45,
+                                dq_vref: 45,
+                                ca_vref: 63,
+                                cs_vref: 56,
+                                d_ca_vref: 48,
+                                d_cs_vref: 58,
+                                rx_dfe: 1,
+                                tx_dfe: 1
+                              }
+                            },
+                            {
+                              header: {
+                                total_size: 12,
+                                target_memclk: 3200,
+                                dimm_slots_per_channel: 1,
+                                dimm0_rank_bitmap: 2,
+                                dimm1_rank_bitmap: 1,
+                                sdram_io_width_bitmap: 1
+                              },
+                              payload: {
+                                total_size: 124,
+                                ca_timing_mode: 1,
+                                dimm0_rttnomwr: 0,
+                                dimm0_rttnomrd: 60,
+                                dimm0_rttwr: 60,
+                                dimm0_rttpack: 60,
+                                dimm0_dqs_rttpark: 60,
+                                dimm1_rttnomwr: 0,
+                                dimm1_rttnomrd: 0,
+                                dimm1_rttwr: 0,
+                                dimm1_rttpack: 0,
+                                dimm1_dqs_rttpark: 0,
+                                dram_drv: 34,
+                                ck_odt_a: 0,
+                                cs_odt_a: 0,
+                                ca_odt_a: 0,
+                                ck_odt_b: 40,
+                                cs_odt_b: 40,
+                                ca_odt_b: 60,
+                                p_odt: 48,
+                                dq_drv: 40,
+                                alert_pullup: 80,
+                                ca_drv: 40,
+                                phy_vref: 93,
+                                dq_vref: 40,
+                                ca_vref: 63,
+                                cs_vref: 56,
+                                d_ca_vref: 48,
+                                d_cs_vref: 58,
+                                rx_dfe: 1,
+                                tx_dfe: 1
+                              }
+                            },
+                            {
+                              header: {
+                                total_size: 12,
+                                target_memclk: 3200,
+                                dimm_slots_per_channel: 1,
+                                dimm0_rank_bitmap: 2,
+                                dimm1_rank_bitmap: 1,
+                                sdram_io_width_bitmap: 2
+                              },
+                              payload: {
+                                total_size: 124,
+                                ca_timing_mode: 1,
+                                dimm0_rttnomwr: 0,
+                                dimm0_rttnomrd: 60,
+                                dimm0_rttwr: 60,
+                                dimm0_rttpack: 60,
+                                dimm0_dqs_rttpark: 60,
+                                dimm1_rttnomwr: 0,
+                                dimm1_rttnomrd: 0,
+                                dimm1_rttwr: 0,
+                                dimm1_rttpack: 0,
+                                dimm1_dqs_rttpark: 0,
+                                dram_drv: 34,
+                                ck_odt_a: 0,
+                                cs_odt_a: 0,
+                                ca_odt_a: 240,
+                                ck_odt_b: 40,
+                                cs_odt_b: 40,
+                                ca_odt_b: 60,
+                                p_odt: 48,
+                                dq_drv: 40,
+                                alert_pullup: 80,
+                                ca_drv: 40,
+                                phy_vref: 93,
+                                dq_vref: 40,
+                                ca_vref: 63,
+                                cs_vref: 56,
+                                d_ca_vref: 48,
+                                d_cs_vref: 58,
+                                rx_dfe: 1,
+                                tx_dfe: 1
+                              }
+                            },
+                            {
+                              header: {
+                                total_size: 12,
+                                target_memclk: 3200,
+                                dimm_slots_per_channel: 1,
+                                dimm0_rank_bitmap: 4,
+                                dimm1_rank_bitmap: 1,
+                                sdram_io_width_bitmap: 255
+                              },
+                              payload: {
+                                total_size: 124,
+                                ca_timing_mode: 1,
+                                dimm0_rttnomwr: 0,
+                                dimm0_rttnomrd: 40,
+                                dimm0_rttwr: 240,
+                                dimm0_rttpack: 40,
+                                dimm0_dqs_rttpark: 40,
+                                dimm1_rttnomwr: 0,
+                                dimm1_rttnomrd: 0,
+                                dimm1_rttwr: 0,
+                                dimm1_rttpack: 0,
+                                dimm1_dqs_rttpark: 0,
+                                dram_drv: 34,
+                                ck_odt_a: 0,
+                                cs_odt_a: 0,
+                                ca_odt_a: 0,
+                                ck_odt_b: 40,
+                                cs_odt_b: 40,
+                                ca_odt_b: 60,
+                                p_odt: 48,
+                                dq_drv: 40,
+                                alert_pullup: 80,
+                                ca_drv: 40,
+                                phy_vref: 45,
+                                dq_vref: 45,
+                                ca_vref: 63,
+                                cs_vref: 56,
+                                d_ca_vref: 48,
+                                d_cs_vref: 58,
+                                rx_dfe: 1,
+                                tx_dfe: 1
+                              }
+                            },
+                            {
+                              header: {
+                                total_size: 12,
+                                target_memclk: 2600,
+                                dimm_slots_per_channel: 2,
+                                dimm0_rank_bitmap: 1,
+                                dimm1_rank_bitmap: 2,
+                                sdram_io_width_bitmap: 1
+                              },
+                              payload: {
+                                total_size: 124,
+                                ca_timing_mode: 1,
+                                dimm0_rttnomwr: 0,
+                                dimm0_rttnomrd: 0,
+                                dimm0_rttwr: 0,
+                                dimm0_rttpack: 0,
+                                dimm0_dqs_rttpark: 0,
+                                dimm1_rttnomwr: 0,
+                                dimm1_rttnomrd: 60,
+                                dimm1_rttwr: 60,
+                                dimm1_rttpack: 60,
+                                dimm1_dqs_rttpark: 60,
+                                dram_drv: 34,
+                                ck_odt_a: 0,
+                                cs_odt_a: 0,
+                                ca_odt_a: 0,
+                                ck_odt_b: 40,
+                                cs_odt_b: 40,
+                                ca_odt_b: 60,
+                                p_odt: 48,
+                                dq_drv: 34,
+                                alert_pullup: 80,
+                                ca_drv: 40,
+                                phy_vref: 93,
+                                dq_vref: 40,
+                                ca_vref: 63,
+                                cs_vref: 56,
+                                d_ca_vref: 48,
+                                d_cs_vref: 58,
+                                rx_dfe: 1,
+                                tx_dfe: 1
+                              }
+                            },
+                            {
+                              header: {
+                                total_size: 12,
+                                target_memclk: 2600,
+                                dimm_slots_per_channel: 2,
+                                dimm0_rank_bitmap: 1,
+                                dimm1_rank_bitmap: 2,
+                                sdram_io_width_bitmap: 2
+                              },
+                              payload: {
+                                total_size: 124,
+                                ca_timing_mode: 1,
+                                dimm0_rttnomwr: 0,
+                                dimm0_rttnomrd: 0,
+                                dimm0_rttwr: 0,
+                                dimm0_rttpack: 0,
+                                dimm0_dqs_rttpark: 0,
+                                dimm1_rttnomwr: 0,
+                                dimm1_rttnomrd: 60,
+                                dimm1_rttwr: 60,
+                                dimm1_rttpack: 60,
+                                dimm1_dqs_rttpark: 60,
+                                dram_drv: 34,
+                                ck_odt_a: 0,
+                                cs_odt_a: 0,
+                                ca_odt_a: 240,
+                                ck_odt_b: 40,
+                                cs_odt_b: 40,
+                                ca_odt_b: 60,
+                                p_odt: 48,
+                                dq_drv: 34,
+                                alert_pullup: 80,
+                                ca_drv: 40,
+                                phy_vref: 93,
+                                dq_vref: 40,
+                                ca_vref: 63,
+                                cs_vref: 56,
+                                d_ca_vref: 48,
+                                d_cs_vref: 58,
+                                rx_dfe: 1,
+                                tx_dfe: 1
+                              }
+                            }
+                          ]
+                        },
+                        {
+                          header: {
+                            group_id: 5892,
+                            entry_id: 137,
+                            instance_id: 44416,
+                            context_type: "Struct",
+                            context_format: "Raw",
+                            unit_size: 0,
+                            priority_mask: {
+                              hard_force: false,
+                              high: false,
+                              medium: false,
+                              event_logging: false,
+                              low: false,
+                              normal: true,
+                            },
+                            key_size: 0,
+                            key_pos: 0,
+                            board_instance_mask: 65535
+                          },
+                          RdimmDdr5BusElement: [
+                            {
+                              header: {
+                                total_size: 12,
+                                target_memclk: 1800,
+                                dimm_slots_per_channel: 2,
+                                dimm0_rank_bitmap: 4,
+                                dimm1_rank_bitmap: 4,
+                                sdram_io_width_bitmap: 255
+                              },
+                              payload: {
+                                total_size: 124,
+                                ca_timing_mode: 1,
+                                dimm0_rttnomwr: 240,
+                                dimm0_rttnomrd: 60,
+                                dimm0_rttwr: 240,
+                                dimm0_rttpack: 60,
+                                dimm0_dqs_rttpark: 60,
+                                dimm1_rttnomwr: 240,
+                                dimm1_rttnomrd: 60,
+                                dimm1_rttwr: 240,
+                                dimm1_rttpack: 60,
+                                dimm1_dqs_rttpark: 60,
+                                dram_drv: 34,
+                                ck_odt_a: 0,
+                                cs_odt_a: 0,
+                                ca_odt_a: 0,
+                                ck_odt_b: 40,
+                                cs_odt_b: 40,
+                                ca_odt_b: 60,
+                                p_odt: 60,
+                                dq_drv: 34,
+                                alert_pullup: 80,
+                                ca_drv: 40,
+                                phy_vref: 45,
+                                dq_vref: 45,
+                                ca_vref: 63,
+                                cs_vref: 56,
+                                d_ca_vref: 32,
+                                d_cs_vref: 40,
+                                rx_dfe: 1,
+                                tx_dfe: 1
+                              }
+                            },
+                            {
+                              header: {
+                                total_size: 12,
+                                target_memclk: 2000,
+                                dimm_slots_per_channel: 2,
+                                dimm0_rank_bitmap: 4,
+                                dimm1_rank_bitmap: 4,
+                                sdram_io_width_bitmap: 255
+                              },
+                              payload: {
+                                total_size: 124,
+                                ca_timing_mode: 1,
+                                dimm0_rttnomwr: 240,
+                                dimm0_rttnomrd: 48,
+                                dimm0_rttwr: 120,
+                                dimm0_rttpack: 48,
+                                dimm0_dqs_rttpark: 60,
+                                dimm1_rttnomwr: 240,
+                                dimm1_rttnomrd: 48,
+                                dimm1_rttwr: 120,
+                                dimm1_rttpack: 48,
+                                dimm1_dqs_rttpark: 60,
+                                dram_drv: 34,
+                                ck_odt_a: 0,
+                                cs_odt_a: 0,
+                                ca_odt_a: 0,
+                                ck_odt_b: 40,
+                                cs_odt_b: 40,
+                                ca_odt_b: 60,
+                                p_odt: 60,
+                                dq_drv: 34,
+                                alert_pullup: 80,
+                                ca_drv: 40,
+                                phy_vref: 45,
+                                dq_vref: 45,
+                                ca_vref: 63,
+                                cs_vref: 56,
+                                d_ca_vref: 32,
+                                d_cs_vref: 40,
+                                rx_dfe: 1,
+                                tx_dfe: 1
+                              }
+                            },
+                            {
+                              header: {
+                                total_size: 12,
+                                target_memclk: 2200,
+                                dimm_slots_per_channel: 2,
+                                dimm0_rank_bitmap: 4,
+                                dimm1_rank_bitmap: 4,
+                                sdram_io_width_bitmap: 1
+                              },
+                              payload: {
+                                total_size: 124,
+                                ca_timing_mode: 1,
+                                dimm0_rttnomwr: 240,
+                                dimm0_rttnomrd: 120,
+                                dimm0_rttwr: 240,
+                                dimm0_rttpack: 60,
+                                dimm0_dqs_rttpark: 60,
+                                dimm1_rttnomwr: 240,
+                                dimm1_rttnomrd: 120,
+                                dimm1_rttwr: 240,
+                                dimm1_rttpack: 60,
+                                dimm1_dqs_rttpark: 60,
+                                dram_drv: 34,
+                                ck_odt_a: 0,
+                                cs_odt_a: 0,
+                                ca_odt_a: 0,
+                                ck_odt_b: 40,
+                                cs_odt_b: 40,
+                                ca_odt_b: 60,
+                                p_odt: 60,
+                                dq_drv: 34,
+                                alert_pullup: 80,
+                                ca_drv: 40,
+                                phy_vref: 45,
+                                dq_vref: 45,
+                                ca_vref: 63,
+                                cs_vref: 56,
+                                d_ca_vref: 32,
+                                d_cs_vref: 40,
+                                rx_dfe: 1,
+                                tx_dfe: 1
+                              }
+                            },
+                            {
+                              header: {
+                                total_size: 12,
+                                target_memclk: 2200,
+                                dimm_slots_per_channel: 2,
+                                dimm0_rank_bitmap: 2,
+                                dimm1_rank_bitmap: 2,
+                                sdram_io_width_bitmap: 1
+                              },
+                              payload: {
+                                total_size: 124,
+                                ca_timing_mode: 1,
+                                dimm0_rttnomwr: 120,
+                                dimm0_rttnomrd: 34,
+                                dimm0_rttwr: 80,
+                                dimm0_rttpack: 34,
+                                dimm0_dqs_rttpark: 48,
+                                dimm1_rttnomwr: 120,
+                                dimm1_rttnomrd: 34,
+                                dimm1_rttwr: 80,
+                                dimm1_rttpack: 34,
+                                dimm1_dqs_rttpark: 48,
+                                dram_drv: 34,
+                                ck_odt_a: 0,
+                                cs_odt_a: 0,
+                                ca_odt_a: 0,
+                                ck_odt_b: 40,
+                                cs_odt_b: 40,
+                                ca_odt_b: 60,
+                                p_odt: 48,
+                                dq_drv: 34,
+                                alert_pullup: 80,
+                                ca_drv: 40,
+                                phy_vref: 45,
+                                dq_vref: 40,
+                                ca_vref: 63,
+                                cs_vref: 56,
+                                d_ca_vref: 32,
+                                d_cs_vref: 40,
+                                rx_dfe: 1,
+                                tx_dfe: 1
+                              }
+                            },
+                            {
+                              header: {
+                                total_size: 12,
+                                target_memclk: 2200,
+                                dimm_slots_per_channel: 2,
+                                dimm0_rank_bitmap: 2,
+                                dimm1_rank_bitmap: 2,
+                                sdram_io_width_bitmap: 2
+                              },
+                              payload: {
+                                total_size: 124,
+                                ca_timing_mode: 1,
+                                dimm0_rttnomwr: 120,
+                                dimm0_rttnomrd: 34,
+                                dimm0_rttwr: 80,
+                                dimm0_rttpack: 34,
+                                dimm0_dqs_rttpark: 48,
+                                dimm1_rttnomwr: 120,
+                                dimm1_rttnomrd: 34,
+                                dimm1_rttwr: 80,
+                                dimm1_rttpack: 34,
+                                dimm1_dqs_rttpark: 48,
+                                dram_drv: 34,
+                                ck_odt_a: 0,
+                                cs_odt_a: 0,
+                                ca_odt_a: 240,
+                                ck_odt_b: 40,
+                                cs_odt_b: 40,
+                                ca_odt_b: 60,
+                                p_odt: 48,
+                                dq_drv: 34,
+                                alert_pullup: 80,
+                                ca_drv: 40,
+                                phy_vref: 45,
+                                dq_vref: 40,
+                                ca_vref: 63,
+                                cs_vref: 56,
+                                d_ca_vref: 32,
+                                d_cs_vref: 40,
+                                rx_dfe: 1,
+                                tx_dfe: 1
+                              }
+                            },
+                            {
+                              header: {
+                                total_size: 12,
+                                target_memclk: 2600,
+                                dimm_slots_per_channel: 2,
+                                dimm0_rank_bitmap: 1,
+                                dimm1_rank_bitmap: 4,
+                                sdram_io_width_bitmap: 255
+                              },
+                              payload: {
+                                total_size: 124,
+                                ca_timing_mode: 1,
+                                dimm0_rttnomwr: 0,
+                                dimm0_rttnomrd: 0,
+                                dimm0_rttwr: 0,
+                                dimm0_rttpack: 0,
+                                dimm0_dqs_rttpark: 0,
+                                dimm1_rttnomwr: 0,
+                                dimm1_rttnomrd: 60,
+                                dimm1_rttwr: 120,
+                                dimm1_rttpack: 60,
+                                dimm1_dqs_rttpark: 60,
+                                dram_drv: 34,
+                                ck_odt_a: 0,
+                                cs_odt_a: 0,
+                                ca_odt_a: 0,
+                                ck_odt_b: 40,
+                                cs_odt_b: 40,
+                                ca_odt_b: 60,
+                                p_odt: 60,
+                                dq_drv: 34,
+                                alert_pullup: 80,
+                                ca_drv: 40,
+                                phy_vref: 45,
+                                dq_vref: 45,
+                                ca_vref: 63,
+                                cs_vref: 56,
+                                d_ca_vref: 48,
+                                d_cs_vref: 58,
+                                rx_dfe: 1,
+                                tx_dfe: 1
+                              }
+                            },
+                            {
+                              header: {
+                                total_size: 12,
+                                target_memclk: 3200,
+                                dimm_slots_per_channel: 1,
+                                dimm0_rank_bitmap: 2,
+                                dimm1_rank_bitmap: 1,
+                                sdram_io_width_bitmap: 1
+                              },
+                              payload: {
+                                total_size: 124,
+                                ca_timing_mode: 1,
+                                dimm0_rttnomwr: 0,
+                                dimm0_rttnomrd: 60,
+                                dimm0_rttwr: 60,
+                                dimm0_rttpack: 60,
+                                dimm0_dqs_rttpark: 60,
+                                dimm1_rttnomwr: 0,
+                                dimm1_rttnomrd: 0,
+                                dimm1_rttwr: 0,
+                                dimm1_rttpack: 0,
+                                dimm1_dqs_rttpark: 0,
+                                dram_drv: 34,
+                                ck_odt_a: 0,
+                                cs_odt_a: 0,
+                                ca_odt_a: 0,
+                                ck_odt_b: 40,
+                                cs_odt_b: 40,
+                                ca_odt_b: 60,
+                                p_odt: 48,
+                                dq_drv: 34,
+                                alert_pullup: 80,
+                                ca_drv: 40,
+                                phy_vref: 93,
+                                dq_vref: 40,
+                                ca_vref: 63,
+                                cs_vref: 56,
+                                d_ca_vref: 48,
+                                d_cs_vref: 58,
+                                rx_dfe: 1,
+                                tx_dfe: 1
+                              }
+                            },
+                            {
+                              header: {
+                                total_size: 12,
+                                target_memclk: 3200,
+                                dimm_slots_per_channel: 1,
+                                dimm0_rank_bitmap: 2,
+                                dimm1_rank_bitmap: 1,
+                                sdram_io_width_bitmap: 2
+                              },
+                              payload: {
+                                total_size: 124,
+                                ca_timing_mode: 1,
+                                dimm0_rttnomwr: 0,
+                                dimm0_rttnomrd: 60,
+                                dimm0_rttwr: 60,
+                                dimm0_rttpack: 60,
+                                dimm0_dqs_rttpark: 60,
+                                dimm1_rttnomwr: 0,
+                                dimm1_rttnomrd: 0,
+                                dimm1_rttwr: 0,
+                                dimm1_rttpack: 0,
+                                dimm1_dqs_rttpark: 0,
+                                dram_drv: 34,
+                                ck_odt_a: 0,
+                                cs_odt_a: 0,
+                                ca_odt_a: 240,
+                                ck_odt_b: 40,
+                                cs_odt_b: 40,
+                                ca_odt_b: 60,
+                                p_odt: 48,
+                                dq_drv: 34,
+                                alert_pullup: 80,
+                                ca_drv: 40,
+                                phy_vref: 93,
+                                dq_vref: 40,
+                                ca_vref: 63,
+                                cs_vref: 56,
+                                d_ca_vref: 48,
+                                d_cs_vref: 58,
+                                rx_dfe: 1,
+                                tx_dfe: 1
+                              }
+                            },
+                            {
+                              header: {
+                                total_size: 12,
+                                target_memclk: 3200,
+                                dimm_slots_per_channel: 1,
+                                dimm0_rank_bitmap: 4,
+                                dimm1_rank_bitmap: 1,
+                                sdram_io_width_bitmap: 255
+                              },
+                              payload: {
+                                total_size: 124,
+                                ca_timing_mode: 1,
+                                dimm0_rttnomwr: 0,
+                                dimm0_rttnomrd: 60,
+                                dimm0_rttwr: 120,
+                                dimm0_rttpack: 60,
+                                dimm0_dqs_rttpark: 60,
+                                dimm1_rttnomwr: 0,
+                                dimm1_rttnomrd: 0,
+                                dimm1_rttwr: 0,
+                                dimm1_rttpack: 0,
+                                dimm1_dqs_rttpark: 0,
+                                dram_drv: 34,
+                                ck_odt_a: 0,
+                                cs_odt_a: 0,
+                                ca_odt_a: 0,
+                                ck_odt_b: 40,
+                                cs_odt_b: 40,
+                                ca_odt_b: 60,
+                                p_odt: 60,
+                                dq_drv: 34,
+                                alert_pullup: 80,
+                                ca_drv: 40,
+                                phy_vref: 45,
+                                dq_vref: 45,
+                                ca_vref: 63,
+                                cs_vref: 56,
+                                d_ca_vref: 48,
+                                d_cs_vref: 58,
+                                rx_dfe: 1,
+                                tx_dfe: 1
+                              }
+                            },
+                            {
+                              header: {
+                                total_size: 12,
+                                target_memclk: 2600,
+                                dimm_slots_per_channel: 2,
+                                dimm0_rank_bitmap: 1,
+                                dimm1_rank_bitmap: 2,
+                                sdram_io_width_bitmap: 1
+                              },
+                              payload: {
+                                total_size: 124,
+                                ca_timing_mode: 1,
+                                dimm0_rttnomwr: 0,
+                                dimm0_rttnomrd: 0,
+                                dimm0_rttwr: 0,
+                                dimm0_rttpack: 0,
+                                dimm0_dqs_rttpark: 0,
+                                dimm1_rttnomwr: 0,
+                                dimm1_rttnomrd: 60,
+                                dimm1_rttwr: 60,
+                                dimm1_rttpack: 60,
+                                dimm1_dqs_rttpark: 60,
+                                dram_drv: 34,
+                                ck_odt_a: 0,
+                                cs_odt_a: 0,
+                                ca_odt_a: 0,
+                                ck_odt_b: 40,
+                                cs_odt_b: 40,
+                                ca_odt_b: 60,
+                                p_odt: 48,
+                                dq_drv: 34,
+                                alert_pullup: 80,
+                                ca_drv: 40,
+                                phy_vref: 93,
+                                dq_vref: 40,
+                                ca_vref: 63,
+                                cs_vref: 56,
+                                d_ca_vref: 48,
+                                d_cs_vref: 58,
+                                rx_dfe: 1,
+                                tx_dfe: 1
+                              }
+                            },
+                            {
+                              header: {
+                                total_size: 12,
+                                target_memclk: 2600,
+                                dimm_slots_per_channel: 2,
+                                dimm0_rank_bitmap: 1,
+                                dimm1_rank_bitmap: 2,
+                                sdram_io_width_bitmap: 2
+                              },
+                              payload: {
+                                total_size: 124,
+                                ca_timing_mode: 1,
+                                dimm0_rttnomwr: 0,
+                                dimm0_rttnomrd: 0,
+                                dimm0_rttwr: 0,
+                                dimm0_rttpack: 0,
+                                dimm0_dqs_rttpark: 0,
+                                dimm1_rttnomwr: 0,
+                                dimm1_rttnomrd: 60,
+                                dimm1_rttwr: 60,
+                                dimm1_rttpack: 60,
+                                dimm1_dqs_rttpark: 60,
+                                dram_drv: 34,
+                                ck_odt_a: 0,
+                                cs_odt_a: 0,
+                                ca_odt_a: 240,
+                                ck_odt_b: 40,
+                                cs_odt_b: 40,
+                                ca_odt_b: 60,
+                                p_odt: 48,
+                                dq_drv: 34,
+                                alert_pullup: 80,
+                                ca_drv: 40,
+                                phy_vref: 93,
+                                dq_vref: 40,
+                                ca_vref: 63,
+                                cs_vref: 56,
+                                d_ca_vref: 48,
+                                d_cs_vref: 58,
+                                rx_dfe: 1,
+                                tx_dfe: 1
+                              }
+                            }
+                          ]
+                        },
+                        {
+                          header: {
+                            group_id: 5892,
+                            entry_id: 137,
+                            instance_id: 44420,
+                            context_type: "Struct",
+                            context_format: "Raw",
+                            unit_size: 0,
+                            priority_mask: {
+                              hard_force: false,
+                              high: false,
+                              medium: false,
+                              event_logging: false,
+                              low: false,
+                              normal: true,
+                            },
+                            key_size: 0,
+                            key_pos: 0,
+                            board_instance_mask: 65535
+                          },
+                          RdimmDdr5BusElement: [
+                            {
+                              header: {
+                                total_size: 12,
+                                target_memclk: 1800,
+                                dimm_slots_per_channel: 2,
+                                dimm0_rank_bitmap: 4,
+                                dimm1_rank_bitmap: 4,
+                                sdram_io_width_bitmap: 255
+                              },
+                              payload: {
+                                total_size: 124,
+                                ca_timing_mode: 1,
+                                dimm0_rttnomwr: 240,
+                                dimm0_rttnomrd: 60,
+                                dimm0_rttwr: 240,
+                                dimm0_rttpack: 60,
+                                dimm0_dqs_rttpark: 60,
+                                dimm1_rttnomwr: 240,
+                                dimm1_rttnomrd: 60,
+                                dimm1_rttwr: 240,
+                                dimm1_rttpack: 60,
+                                dimm1_dqs_rttpark: 60,
+                                dram_drv: 34,
+                                ck_odt_a: 0,
+                                cs_odt_a: 0,
+                                ca_odt_a: 0,
+                                ck_odt_b: 40,
+                                cs_odt_b: 40,
+                                ca_odt_b: 60,
+                                p_odt: 60,
+                                dq_drv: 34,
+                                alert_pullup: 80,
+                                ca_drv: 40,
+                                phy_vref: 45,
+                                dq_vref: 45,
+                                ca_vref: 63,
+                                cs_vref: 56,
+                                d_ca_vref: 32,
+                                d_cs_vref: 40,
+                                rx_dfe: 1,
+                                tx_dfe: 1
+                              }
+                            },
+                            {
+                              header: {
+                                total_size: 12,
+                                target_memclk: 2000,
+                                dimm_slots_per_channel: 2,
+                                dimm0_rank_bitmap: 4,
+                                dimm1_rank_bitmap: 4,
+                                sdram_io_width_bitmap: 255
+                              },
+                              payload: {
+                                total_size: 124,
+                                ca_timing_mode: 1,
+                                dimm0_rttnomwr: 240,
+                                dimm0_rttnomrd: 48,
+                                dimm0_rttwr: 120,
+                                dimm0_rttpack: 48,
+                                dimm0_dqs_rttpark: 60,
+                                dimm1_rttnomwr: 240,
+                                dimm1_rttnomrd: 48,
+                                dimm1_rttwr: 120,
+                                dimm1_rttpack: 48,
+                                dimm1_dqs_rttpark: 60,
+                                dram_drv: 34,
+                                ck_odt_a: 0,
+                                cs_odt_a: 0,
+                                ca_odt_a: 0,
+                                ck_odt_b: 40,
+                                cs_odt_b: 40,
+                                ca_odt_b: 60,
+                                p_odt: 60,
+                                dq_drv: 34,
+                                alert_pullup: 80,
+                                ca_drv: 40,
+                                phy_vref: 45,
+                                dq_vref: 45,
+                                ca_vref: 63,
+                                cs_vref: 56,
+                                d_ca_vref: 32,
+                                d_cs_vref: 40,
+                                rx_dfe: 1,
+                                tx_dfe: 1
+                              }
+                            },
+                            {
+                              header: {
+                                total_size: 12,
+                                target_memclk: 2200,
+                                dimm_slots_per_channel: 2,
+                                dimm0_rank_bitmap: 4,
+                                dimm1_rank_bitmap: 4,
+                                sdram_io_width_bitmap: 1
+                              },
+                              payload: {
+                                total_size: 124,
+                                ca_timing_mode: 1,
+                                dimm0_rttnomwr: 240,
+                                dimm0_rttnomrd: 120,
+                                dimm0_rttwr: 240,
+                                dimm0_rttpack: 60,
+                                dimm0_dqs_rttpark: 60,
+                                dimm1_rttnomwr: 240,
+                                dimm1_rttnomrd: 120,
+                                dimm1_rttwr: 240,
+                                dimm1_rttpack: 60,
+                                dimm1_dqs_rttpark: 60,
+                                dram_drv: 34,
+                                ck_odt_a: 0,
+                                cs_odt_a: 0,
+                                ca_odt_a: 0,
+                                ck_odt_b: 40,
+                                cs_odt_b: 40,
+                                ca_odt_b: 60,
+                                p_odt: 60,
+                                dq_drv: 34,
+                                alert_pullup: 80,
+                                ca_drv: 40,
+                                phy_vref: 45,
+                                dq_vref: 45,
+                                ca_vref: 63,
+                                cs_vref: 56,
+                                d_ca_vref: 32,
+                                d_cs_vref: 40,
+                                rx_dfe: 1,
+                                tx_dfe: 1
+                              }
+                            },
+                            {
+                              header: {
+                                total_size: 12,
+                                target_memclk: 2200,
+                                dimm_slots_per_channel: 2,
+                                dimm0_rank_bitmap: 2,
+                                dimm1_rank_bitmap: 2,
+                                sdram_io_width_bitmap: 1
+                              },
+                              payload: {
+                                total_size: 124,
+                                ca_timing_mode: 1,
+                                dimm0_rttnomwr: 120,
+                                dimm0_rttnomrd: 34,
+                                dimm0_rttwr: 80,
+                                dimm0_rttpack: 34,
+                                dimm0_dqs_rttpark: 48,
+                                dimm1_rttnomwr: 120,
+                                dimm1_rttnomrd: 34,
+                                dimm1_rttwr: 80,
+                                dimm1_rttpack: 34,
+                                dimm1_dqs_rttpark: 48,
+                                dram_drv: 34,
+                                ck_odt_a: 0,
+                                cs_odt_a: 0,
+                                ca_odt_a: 0,
+                                ck_odt_b: 40,
+                                cs_odt_b: 40,
+                                ca_odt_b: 60,
+                                p_odt: 48,
+                                dq_drv: 34,
+                                alert_pullup: 80,
+                                ca_drv: 40,
+                                phy_vref: 45,
+                                dq_vref: 40,
+                                ca_vref: 63,
+                                cs_vref: 56,
+                                d_ca_vref: 32,
+                                d_cs_vref: 40,
+                                rx_dfe: 1,
+                                tx_dfe: 1
+                              }
+                            },
+                            {
+                              header: {
+                                total_size: 12,
+                                target_memclk: 2200,
+                                dimm_slots_per_channel: 2,
+                                dimm0_rank_bitmap: 2,
+                                dimm1_rank_bitmap: 2,
+                                sdram_io_width_bitmap: 2
+                              },
+                              payload: {
+                                total_size: 124,
+                                ca_timing_mode: 1,
+                                dimm0_rttnomwr: 120,
+                                dimm0_rttnomrd: 34,
+                                dimm0_rttwr: 80,
+                                dimm0_rttpack: 34,
+                                dimm0_dqs_rttpark: 48,
+                                dimm1_rttnomwr: 120,
+                                dimm1_rttnomrd: 34,
+                                dimm1_rttwr: 80,
+                                dimm1_rttpack: 34,
+                                dimm1_dqs_rttpark: 48,
+                                dram_drv: 34,
+                                ck_odt_a: 0,
+                                cs_odt_a: 0,
+                                ca_odt_a: 240,
+                                ck_odt_b: 40,
+                                cs_odt_b: 40,
+                                ca_odt_b: 60,
+                                p_odt: 48,
+                                dq_drv: 34,
+                                alert_pullup: 80,
+                                ca_drv: 40,
+                                phy_vref: 45,
+                                dq_vref: 40,
+                                ca_vref: 63,
+                                cs_vref: 56,
+                                d_ca_vref: 32,
+                                d_cs_vref: 40,
+                                rx_dfe: 1,
+                                tx_dfe: 1
+                              }
+                            },
+                            {
+                              header: {
+                                total_size: 12,
+                                target_memclk: 2600,
+                                dimm_slots_per_channel: 2,
+                                dimm0_rank_bitmap: 1,
+                                dimm1_rank_bitmap: 4,
+                                sdram_io_width_bitmap: 255
+                              },
+                              payload: {
+                                total_size: 124,
+                                ca_timing_mode: 1,
+                                dimm0_rttnomwr: 0,
+                                dimm0_rttnomrd: 0,
+                                dimm0_rttwr: 0,
+                                dimm0_rttpack: 0,
+                                dimm0_dqs_rttpark: 0,
+                                dimm1_rttnomwr: 0,
+                                dimm1_rttnomrd: 60,
+                                dimm1_rttwr: 120,
+                                dimm1_rttpack: 60,
+                                dimm1_dqs_rttpark: 60,
+                                dram_drv: 34,
+                                ck_odt_a: 0,
+                                cs_odt_a: 0,
+                                ca_odt_a: 0,
+                                ck_odt_b: 40,
+                                cs_odt_b: 40,
+                                ca_odt_b: 60,
+                                p_odt: 60,
+                                dq_drv: 34,
+                                alert_pullup: 80,
+                                ca_drv: 40,
+                                phy_vref: 45,
+                                dq_vref: 45,
+                                ca_vref: 63,
+                                cs_vref: 56,
+                                d_ca_vref: 48,
+                                d_cs_vref: 58,
+                                rx_dfe: 1,
+                                tx_dfe: 1
+                              }
+                            },
+                            {
+                              header: {
+                                total_size: 12,
+                                target_memclk: 3200,
+                                dimm_slots_per_channel: 1,
+                                dimm0_rank_bitmap: 2,
+                                dimm1_rank_bitmap: 1,
+                                sdram_io_width_bitmap: 1
+                              },
+                              payload: {
+                                total_size: 124,
+                                ca_timing_mode: 1,
+                                dimm0_rttnomwr: 0,
+                                dimm0_rttnomrd: 60,
+                                dimm0_rttwr: 60,
+                                dimm0_rttpack: 60,
+                                dimm0_dqs_rttpark: 60,
+                                dimm1_rttnomwr: 0,
+                                dimm1_rttnomrd: 0,
+                                dimm1_rttwr: 0,
+                                dimm1_rttpack: 0,
+                                dimm1_dqs_rttpark: 0,
+                                dram_drv: 34,
+                                ck_odt_a: 0,
+                                cs_odt_a: 0,
+                                ca_odt_a: 0,
+                                ck_odt_b: 40,
+                                cs_odt_b: 40,
+                                ca_odt_b: 60,
+                                p_odt: 48,
+                                dq_drv: 34,
+                                alert_pullup: 80,
+                                ca_drv: 40,
+                                phy_vref: 93,
+                                dq_vref: 40,
+                                ca_vref: 63,
+                                cs_vref: 56,
+                                d_ca_vref: 48,
+                                d_cs_vref: 58,
+                                rx_dfe: 1,
+                                tx_dfe: 1
+                              }
+                            },
+                            {
+                              header: {
+                                total_size: 12,
+                                target_memclk: 3200,
+                                dimm_slots_per_channel: 1,
+                                dimm0_rank_bitmap: 2,
+                                dimm1_rank_bitmap: 1,
+                                sdram_io_width_bitmap: 2
+                              },
+                              payload: {
+                                total_size: 124,
+                                ca_timing_mode: 1,
+                                dimm0_rttnomwr: 0,
+                                dimm0_rttnomrd: 60,
+                                dimm0_rttwr: 60,
+                                dimm0_rttpack: 60,
+                                dimm0_dqs_rttpark: 60,
+                                dimm1_rttnomwr: 0,
+                                dimm1_rttnomrd: 0,
+                                dimm1_rttwr: 0,
+                                dimm1_rttpack: 0,
+                                dimm1_dqs_rttpark: 0,
+                                dram_drv: 34,
+                                ck_odt_a: 0,
+                                cs_odt_a: 0,
+                                ca_odt_a: 240,
+                                ck_odt_b: 40,
+                                cs_odt_b: 40,
+                                ca_odt_b: 60,
+                                p_odt: 48,
+                                dq_drv: 34,
+                                alert_pullup: 80,
+                                ca_drv: 40,
+                                phy_vref: 93,
+                                dq_vref: 40,
+                                ca_vref: 63,
+                                cs_vref: 56,
+                                d_ca_vref: 48,
+                                d_cs_vref: 58,
+                                rx_dfe: 1,
+                                tx_dfe: 1
+                              }
+                            },
+                            {
+                              header: {
+                                total_size: 12,
+                                target_memclk: 3200,
+                                dimm_slots_per_channel: 1,
+                                dimm0_rank_bitmap: 4,
+                                dimm1_rank_bitmap: 1,
+                                sdram_io_width_bitmap: 255
+                              },
+                              payload: {
+                                total_size: 124,
+                                ca_timing_mode: 1,
+                                dimm0_rttnomwr: 0,
+                                dimm0_rttnomrd: 60,
+                                dimm0_rttwr: 120,
+                                dimm0_rttpack: 60,
+                                dimm0_dqs_rttpark: 60,
+                                dimm1_rttnomwr: 0,
+                                dimm1_rttnomrd: 0,
+                                dimm1_rttwr: 0,
+                                dimm1_rttpack: 0,
+                                dimm1_dqs_rttpark: 0,
+                                dram_drv: 34,
+                                ck_odt_a: 0,
+                                cs_odt_a: 0,
+                                ca_odt_a: 0,
+                                ck_odt_b: 40,
+                                cs_odt_b: 40,
+                                ca_odt_b: 60,
+                                p_odt: 60,
+                                dq_drv: 34,
+                                alert_pullup: 80,
+                                ca_drv: 40,
+                                phy_vref: 45,
+                                dq_vref: 45,
+                                ca_vref: 63,
+                                cs_vref: 56,
+                                d_ca_vref: 48,
+                                d_cs_vref: 58,
+                                rx_dfe: 1,
+                                tx_dfe: 1
+                              }
+                            },
+                            {
+                              header: {
+                                total_size: 12,
+                                target_memclk: 2600,
+                                dimm_slots_per_channel: 2,
+                                dimm0_rank_bitmap: 1,
+                                dimm1_rank_bitmap: 2,
+                                sdram_io_width_bitmap: 1
+                              },
+                              payload: {
+                                total_size: 124,
+                                ca_timing_mode: 1,
+                                dimm0_rttnomwr: 0,
+                                dimm0_rttnomrd: 0,
+                                dimm0_rttwr: 0,
+                                dimm0_rttpack: 0,
+                                dimm0_dqs_rttpark: 0,
+                                dimm1_rttnomwr: 0,
+                                dimm1_rttnomrd: 60,
+                                dimm1_rttwr: 60,
+                                dimm1_rttpack: 60,
+                                dimm1_dqs_rttpark: 60,
+                                dram_drv: 34,
+                                ck_odt_a: 0,
+                                cs_odt_a: 0,
+                                ca_odt_a: 0,
+                                ck_odt_b: 40,
+                                cs_odt_b: 40,
+                                ca_odt_b: 60,
+                                p_odt: 48,
+                                dq_drv: 34,
+                                alert_pullup: 80,
+                                ca_drv: 40,
+                                phy_vref: 93,
+                                dq_vref: 40,
+                                ca_vref: 63,
+                                cs_vref: 56,
+                                d_ca_vref: 48,
+                                d_cs_vref: 58,
+                                rx_dfe: 1,
+                                tx_dfe: 1
+                              }
+                            },
+                            {
+                              header: {
+                                total_size: 12,
+                                target_memclk: 2600,
+                                dimm_slots_per_channel: 2,
+                                dimm0_rank_bitmap: 1,
+                                dimm1_rank_bitmap: 2,
+                                sdram_io_width_bitmap: 2
+                              },
+                              payload: {
+                                total_size: 124,
+                                ca_timing_mode: 1,
+                                dimm0_rttnomwr: 0,
+                                dimm0_rttnomrd: 0,
+                                dimm0_rttwr: 0,
+                                dimm0_rttpack: 0,
+                                dimm0_dqs_rttpark: 0,
+                                dimm1_rttnomwr: 0,
+                                dimm1_rttnomrd: 60,
+                                dimm1_rttwr: 60,
+                                dimm1_rttpack: 60,
+                                dimm1_dqs_rttpark: 60,
+                                dram_drv: 34,
+                                ck_odt_a: 0,
+                                cs_odt_a: 0,
+                                ca_odt_a: 240,
+                                ck_odt_b: 40,
+                                cs_odt_b: 40,
+                                ca_odt_b: 60,
+                                p_odt: 48,
+                                dq_drv: 34,
+                                alert_pullup: 80,
+                                ca_drv: 40,
+                                phy_vref: 93,
+                                dq_vref: 40,
+                                ca_vref: 63,
+                                cs_vref: 56,
+                                d_ca_vref: 48,
+                                d_cs_vref: 58,
+                                rx_dfe: 1,
+                                tx_dfe: 1
+                              }
+                            }
+                          ]
+                        },
+                        {
+                          header: {
+                            group_id: 5892,
+                            entry_id: 137,
+                            instance_id: 44422,
+                            context_type: "Struct",
+                            context_format: "Raw",
+                            unit_size: 0,
+                            priority_mask: {
+                              hard_force: false,
+                              high: false,
+                              medium: false,
+                              event_logging: false,
+                              low: false,
+                              normal: true,
+                            },
+                            key_size: 0,
+                            key_pos: 0,
+                            board_instance_mask: 65535
+                          },
+                          RdimmDdr5BusElement: [
+                            {
+                              header: {
+                                total_size: 12,
+                                target_memclk: 2000,
+                                dimm_slots_per_channel: 2,
+                                dimm0_rank_bitmap: 4,
+                                dimm1_rank_bitmap: 4,
+                                sdram_io_width_bitmap: 255
+                              },
+                              payload: {
+                                total_size: 124,
+                                ca_timing_mode: 1,
+                                dimm0_rttnomwr: 240,
+                                dimm0_rttnomrd: 60,
+                                dimm0_rttwr: 240,
+                                dimm0_rttpack: 60,
+                                dimm0_dqs_rttpark: 60,
+                                dimm1_rttnomwr: 240,
+                                dimm1_rttnomrd: 60,
+                                dimm1_rttwr: 240,
+                                dimm1_rttpack: 60,
+                                dimm1_dqs_rttpark: 60,
+                                dram_drv: 34,
+                                ck_odt_a: 0,
+                                cs_odt_a: 0,
+                                ca_odt_a: 0,
+                                ck_odt_b: 40,
+                                cs_odt_b: 40,
+                                ca_odt_b: 60,
+                                p_odt: 60,
+                                dq_drv: 34,
+                                alert_pullup: 80,
+                                ca_drv: 40,
+                                phy_vref: 45,
+                                dq_vref: 45,
+                                ca_vref: 63,
+                                cs_vref: 56,
+                                d_ca_vref: 32,
+                                d_cs_vref: 40,
+                                rx_dfe: 1,
+                                tx_dfe: 1
+                              }
+                            },
+                            {
+                              header: {
+                                total_size: 12,
+                                target_memclk: 2200,
+                                dimm_slots_per_channel: 2,
+                                dimm0_rank_bitmap: 4,
+                                dimm1_rank_bitmap: 4,
+                                sdram_io_width_bitmap: 1
+                              },
+                              payload: {
+                                total_size: 124,
+                                ca_timing_mode: 1,
+                                dimm0_rttnomwr: 240,
+                                dimm0_rttnomrd: 120,
+                                dimm0_rttwr: 240,
+                                dimm0_rttpack: 60,
+                                dimm0_dqs_rttpark: 60,
+                                dimm1_rttnomwr: 240,
+                                dimm1_rttnomrd: 120,
+                                dimm1_rttwr: 240,
+                                dimm1_rttpack: 60,
+                                dimm1_dqs_rttpark: 60,
+                                dram_drv: 34,
+                                ck_odt_a: 0,
+                                cs_odt_a: 0,
+                                ca_odt_a: 0,
+                                ck_odt_b: 40,
+                                cs_odt_b: 40,
+                                ca_odt_b: 60,
+                                p_odt: 60,
+                                dq_drv: 34,
+                                alert_pullup: 80,
+                                ca_drv: 40,
+                                phy_vref: 45,
+                                dq_vref: 45,
+                                ca_vref: 63,
+                                cs_vref: 56,
+                                d_ca_vref: 32,
+                                d_cs_vref: 40,
+                                rx_dfe: 1,
+                                tx_dfe: 1
+                              }
+                            },
+                            {
+                              header: {
+                                total_size: 12,
+                                target_memclk: 2200,
+                                dimm_slots_per_channel: 2,
+                                dimm0_rank_bitmap: 2,
+                                dimm1_rank_bitmap: 2,
+                                sdram_io_width_bitmap: 1
+                              },
+                              payload: {
+                                total_size: 124,
+                                ca_timing_mode: 1,
+                                dimm0_rttnomwr: 120,
+                                dimm0_rttnomrd: 34,
+                                dimm0_rttwr: 80,
+                                dimm0_rttpack: 34,
+                                dimm0_dqs_rttpark: 48,
+                                dimm1_rttnomwr: 120,
+                                dimm1_rttnomrd: 34,
+                                dimm1_rttwr: 80,
+                                dimm1_rttpack: 34,
+                                dimm1_dqs_rttpark: 48,
+                                dram_drv: 34,
+                                ck_odt_a: 0,
+                                cs_odt_a: 0,
+                                ca_odt_a: 0,
+                                ck_odt_b: 40,
+                                cs_odt_b: 40,
+                                ca_odt_b: 60,
+                                p_odt: 48,
+                                dq_drv: 34,
+                                alert_pullup: 80,
+                                ca_drv: 40,
+                                phy_vref: 45,
+                                dq_vref: 40,
+                                ca_vref: 63,
+                                cs_vref: 56,
+                                d_ca_vref: 32,
+                                d_cs_vref: 40,
+                                rx_dfe: 1,
+                                tx_dfe: 1
+                              }
+                            },
+                            {
+                              header: {
+                                total_size: 12,
+                                target_memclk: 2200,
+                                dimm_slots_per_channel: 2,
+                                dimm0_rank_bitmap: 2,
+                                dimm1_rank_bitmap: 2,
+                                sdram_io_width_bitmap: 2
+                              },
+                              payload: {
+                                total_size: 124,
+                                ca_timing_mode: 1,
+                                dimm0_rttnomwr: 120,
+                                dimm0_rttnomrd: 34,
+                                dimm0_rttwr: 80,
+                                dimm0_rttpack: 34,
+                                dimm0_dqs_rttpark: 48,
+                                dimm1_rttnomwr: 120,
+                                dimm1_rttnomrd: 34,
+                                dimm1_rttwr: 80,
+                                dimm1_rttpack: 34,
+                                dimm1_dqs_rttpark: 48,
+                                dram_drv: 34,
+                                ck_odt_a: 0,
+                                cs_odt_a: 0,
+                                ca_odt_a: 240,
+                                ck_odt_b: 40,
+                                cs_odt_b: 40,
+                                ca_odt_b: 60,
+                                p_odt: 48,
+                                dq_drv: 34,
+                                alert_pullup: 80,
+                                ca_drv: 40,
+                                phy_vref: 45,
+                                dq_vref: 40,
+                                ca_vref: 63,
+                                cs_vref: 56,
+                                d_ca_vref: 32,
+                                d_cs_vref: 40,
+                                rx_dfe: 1,
+                                tx_dfe: 1
+                              }
+                            },
+                            {
+                              header: {
+                                total_size: 12,
+                                target_memclk: 2600,
+                                dimm_slots_per_channel: 2,
+                                dimm0_rank_bitmap: 1,
+                                dimm1_rank_bitmap: 4,
+                                sdram_io_width_bitmap: 255
+                              },
+                              payload: {
+                                total_size: 124,
+                                ca_timing_mode: 1,
+                                dimm0_rttnomwr: 0,
+                                dimm0_rttnomrd: 0,
+                                dimm0_rttwr: 0,
+                                dimm0_rttpack: 0,
+                                dimm0_dqs_rttpark: 0,
+                                dimm1_rttnomwr: 0,
+                                dimm1_rttnomrd: 60,
+                                dimm1_rttwr: 120,
+                                dimm1_rttpack: 60,
+                                dimm1_dqs_rttpark: 60,
+                                dram_drv: 34,
+                                ck_odt_a: 0,
+                                cs_odt_a: 0,
+                                ca_odt_a: 0,
+                                ck_odt_b: 40,
+                                cs_odt_b: 40,
+                                ca_odt_b: 60,
+                                p_odt: 60,
+                                dq_drv: 34,
+                                alert_pullup: 80,
+                                ca_drv: 40,
+                                phy_vref: 45,
+                                dq_vref: 45,
+                                ca_vref: 63,
+                                cs_vref: 56,
+                                d_ca_vref: 48,
+                                d_cs_vref: 58,
+                                rx_dfe: 1,
+                                tx_dfe: 1
+                              }
+                            },
+                            {
+                              header: {
+                                total_size: 12,
+                                target_memclk: 3200,
+                                dimm_slots_per_channel: 1,
+                                dimm0_rank_bitmap: 2,
+                                dimm1_rank_bitmap: 1,
+                                sdram_io_width_bitmap: 1
+                              },
+                              payload: {
+                                total_size: 124,
+                                ca_timing_mode: 1,
+                                dimm0_rttnomwr: 0,
+                                dimm0_rttnomrd: 60,
+                                dimm0_rttwr: 60,
+                                dimm0_rttpack: 60,
+                                dimm0_dqs_rttpark: 60,
+                                dimm1_rttnomwr: 0,
+                                dimm1_rttnomrd: 0,
+                                dimm1_rttwr: 0,
+                                dimm1_rttpack: 0,
+                                dimm1_dqs_rttpark: 0,
+                                dram_drv: 34,
+                                ck_odt_a: 0,
+                                cs_odt_a: 0,
+                                ca_odt_a: 0,
+                                ck_odt_b: 40,
+                                cs_odt_b: 40,
+                                ca_odt_b: 60,
+                                p_odt: 48,
+                                dq_drv: 34,
+                                alert_pullup: 80,
+                                ca_drv: 40,
+                                phy_vref: 93,
+                                dq_vref: 40,
+                                ca_vref: 63,
+                                cs_vref: 56,
+                                d_ca_vref: 48,
+                                d_cs_vref: 58,
+                                rx_dfe: 1,
+                                tx_dfe: 1
+                              }
+                            },
+                            {
+                              header: {
+                                total_size: 12,
+                                target_memclk: 3200,
+                                dimm_slots_per_channel: 1,
+                                dimm0_rank_bitmap: 2,
+                                dimm1_rank_bitmap: 1,
+                                sdram_io_width_bitmap: 2
+                              },
+                              payload: {
+                                total_size: 124,
+                                ca_timing_mode: 1,
+                                dimm0_rttnomwr: 0,
+                                dimm0_rttnomrd: 60,
+                                dimm0_rttwr: 60,
+                                dimm0_rttpack: 60,
+                                dimm0_dqs_rttpark: 60,
+                                dimm1_rttnomwr: 0,
+                                dimm1_rttnomrd: 0,
+                                dimm1_rttwr: 0,
+                                dimm1_rttpack: 0,
+                                dimm1_dqs_rttpark: 0,
+                                dram_drv: 34,
+                                ck_odt_a: 0,
+                                cs_odt_a: 0,
+                                ca_odt_a: 240,
+                                ck_odt_b: 40,
+                                cs_odt_b: 40,
+                                ca_odt_b: 60,
+                                p_odt: 48,
+                                dq_drv: 34,
+                                alert_pullup: 80,
+                                ca_drv: 40,
+                                phy_vref: 93,
+                                dq_vref: 40,
+                                ca_vref: 63,
+                                cs_vref: 56,
+                                d_ca_vref: 48,
+                                d_cs_vref: 58,
+                                rx_dfe: 1,
+                                tx_dfe: 1
+                              }
+                            },
+                            {
+                              header: {
+                                total_size: 12,
+                                target_memclk: 3000,
+                                dimm_slots_per_channel: 1,
+                                dimm0_rank_bitmap: 4,
+                                dimm1_rank_bitmap: 1,
+                                sdram_io_width_bitmap: 255
+                              },
+                              payload: {
+                                total_size: 124,
+                                ca_timing_mode: 1,
+                                dimm0_rttnomwr: 0,
+                                dimm0_rttnomrd: 40,
+                                dimm0_rttwr: 240,
+                                dimm0_rttpack: 40,
+                                dimm0_dqs_rttpark: 60,
+                                dimm1_rttnomwr: 0,
+                                dimm1_rttnomrd: 0,
+                                dimm1_rttwr: 0,
+                                dimm1_rttpack: 0,
+                                dimm1_dqs_rttpark: 0,
+                                dram_drv: 34,
+                                ck_odt_a: 0,
+                                cs_odt_a: 0,
+                                ca_odt_a: 0,
+                                ck_odt_b: 40,
+                                cs_odt_b: 40,
+                                ca_odt_b: 60,
+                                p_odt: 53,
+                                dq_drv: 34,
+                                alert_pullup: 80,
+                                ca_drv: 40,
+                                phy_vref: 45,
+                                dq_vref: 45,
+                                ca_vref: 63,
+                                cs_vref: 56,
+                                d_ca_vref: 48,
+                                d_cs_vref: 58,
+                                rx_dfe: 1,
+                                tx_dfe: 1
+                              }
+                            },
+                            {
+                              header: {
+                                total_size: 12,
+                                target_memclk: 3200,
+                                dimm_slots_per_channel: 1,
+                                dimm0_rank_bitmap: 4,
+                                dimm1_rank_bitmap: 1,
+                                sdram_io_width_bitmap: 1
+                              },
+                              payload: {
+                                total_size: 124,
+                                ca_timing_mode: 1,
+                                dimm0_rttnomwr: 0,
+                                dimm0_rttnomrd: 40,
+                                dimm0_rttwr: 240,
+                                dimm0_rttpack: 40,
+                                dimm0_dqs_rttpark: 60,
+                                dimm1_rttnomwr: 0,
+                                dimm1_rttnomrd: 0,
+                                dimm1_rttwr: 0,
+                                dimm1_rttpack: 0,
+                                dimm1_dqs_rttpark: 0,
+                                dram_drv: 34,
+                                ck_odt_a: 0,
+                                cs_odt_a: 0,
+                                ca_odt_a: 0,
+                                ck_odt_b: 40,
+                                cs_odt_b: 40,
+                                ca_odt_b: 60,
+                                p_odt: 53,
+                                dq_drv: 34,
+                                alert_pullup: 80,
+                                ca_drv: 40,
+                                phy_vref: 45,
+                                dq_vref: 45,
+                                ca_vref: 63,
+                                cs_vref: 56,
+                                d_ca_vref: 48,
+                                d_cs_vref: 58,
+                                rx_dfe: 1,
+                                tx_dfe: 1
+                              }
+                            },
+                            {
+                              header: {
+                                total_size: 12,
+                                target_memclk: 3200,
+                                dimm_slots_per_channel: 1,
+                                dimm0_rank_bitmap: 4,
+                                dimm1_rank_bitmap: 1,
+                                sdram_io_width_bitmap: 2
+                              },
+                              payload: {
+                                total_size: 124,
+                                ca_timing_mode: 1,
+                                dimm0_rttnomwr: 0,
+                                dimm0_rttnomrd: 40,
+                                dimm0_rttwr: 80,
+                                dimm0_rttpack: 40,
+                                dimm0_dqs_rttpark: 40,
+                                dimm1_rttnomwr: 0,
+                                dimm1_rttnomrd: 0,
+                                dimm1_rttwr: 0,
+                                dimm1_rttpack: 0,
+                                dimm1_dqs_rttpark: 0,
+                                dram_drv: 34,
+                                ck_odt_a: 0,
+                                cs_odt_a: 0,
+                                ca_odt_a: 0,
+                                ck_odt_b: 40,
+                                cs_odt_b: 40,
+                                ca_odt_b: 60,
+                                p_odt: 48,
+                                dq_drv: 34,
+                                alert_pullup: 80,
+                                ca_drv: 40,
+                                phy_vref: 45,
+                                dq_vref: 45,
+                                ca_vref: 63,
+                                cs_vref: 56,
+                                d_ca_vref: 48,
+                                d_cs_vref: 58,
+                                rx_dfe: 1,
+                                tx_dfe: 1
+                              }
+                            },
+                            {
+                              header: {
+                                total_size: 12,
+                                target_memclk: 2600,
+                                dimm_slots_per_channel: 2,
+                                dimm0_rank_bitmap: 1,
+                                dimm1_rank_bitmap: 2,
+                                sdram_io_width_bitmap: 1
+                              },
+                              payload: {
+                                total_size: 124,
+                                ca_timing_mode: 1,
+                                dimm0_rttnomwr: 0,
+                                dimm0_rttnomrd: 0,
+                                dimm0_rttwr: 0,
+                                dimm0_rttpack: 0,
+                                dimm0_dqs_rttpark: 0,
+                                dimm1_rttnomwr: 0,
+                                dimm1_rttnomrd: 60,
+                                dimm1_rttwr: 60,
+                                dimm1_rttpack: 60,
+                                dimm1_dqs_rttpark: 60,
+                                dram_drv: 34,
+                                ck_odt_a: 0,
+                                cs_odt_a: 0,
+                                ca_odt_a: 0,
+                                ck_odt_b: 40,
+                                cs_odt_b: 40,
+                                ca_odt_b: 60,
+                                p_odt: 48,
+                                dq_drv: 34,
+                                alert_pullup: 80,
+                                ca_drv: 40,
+                                phy_vref: 93,
+                                dq_vref: 40,
+                                ca_vref: 63,
+                                cs_vref: 56,
+                                d_ca_vref: 48,
+                                d_cs_vref: 58,
+                                rx_dfe: 1,
+                                tx_dfe: 1
+                              }
+                            },
+                            {
+                              header: {
+                                total_size: 12,
+                                target_memclk: 2600,
+                                dimm_slots_per_channel: 2,
+                                dimm0_rank_bitmap: 1,
+                                dimm1_rank_bitmap: 2,
+                                sdram_io_width_bitmap: 2
+                              },
+                              payload: {
+                                total_size: 124,
+                                ca_timing_mode: 1,
+                                dimm0_rttnomwr: 0,
+                                dimm0_rttnomrd: 0,
+                                dimm0_rttwr: 0,
+                                dimm0_rttpack: 0,
+                                dimm0_dqs_rttpark: 0,
+                                dimm1_rttnomwr: 0,
+                                dimm1_rttnomrd: 60,
+                                dimm1_rttwr: 60,
+                                dimm1_rttpack: 60,
+                                dimm1_dqs_rttpark: 60,
+                                dram_drv: 34,
+                                ck_odt_a: 0,
+                                cs_odt_a: 0,
+                                ca_odt_a: 240,
+                                ck_odt_b: 40,
+                                cs_odt_b: 40,
+                                ca_odt_b: 60,
+                                p_odt: 48,
+                                dq_drv: 34,
+                                alert_pullup: 80,
+                                ca_drv: 40,
+                                phy_vref: 93,
+                                dq_vref: 40,
+                                ca_vref: 63,
+                                cs_vref: 56,
+                                d_ca_vref: 48,
+                                d_cs_vref: 58,
+                                rx_dfe: 1,
+                                tx_dfe: 1
+                              }
+                            }
+                          ]
+                        },
+                        {
+                          header: {
+                            group_id: 5892,
+                            entry_id: 137,
+                            instance_id: 52864,
+                            context_type: "Struct",
+                            context_format: "Raw",
+                            unit_size: 0,
+                            priority_mask: {
+                              hard_force: false,
+                              high: false,
+                              medium: false,
+                              event_logging: false,
+                              low: false,
+                              normal: true,
+                            },
+                            key_size: 0,
+                            key_pos: 0,
+                            board_instance_mask: 65535
+                          },
+                          RdimmDdr5BusElement: [
+                            {
+                              header: {
+                                total_size: 12,
+                                target_memclk: 1800,
+                                dimm_slots_per_channel: 2,
+                                dimm0_rank_bitmap: 4,
+                                dimm1_rank_bitmap: 4,
+                                sdram_io_width_bitmap: 255
+                              },
+                              payload: {
+                                total_size: 124,
+                                ca_timing_mode: 1,
+                                dimm0_rttnomwr: 240,
+                                dimm0_rttnomrd: 60,
+                                dimm0_rttwr: 240,
+                                dimm0_rttpack: 60,
+                                dimm0_dqs_rttpark: 60,
+                                dimm1_rttnomwr: 240,
+                                dimm1_rttnomrd: 60,
+                                dimm1_rttwr: 240,
+                                dimm1_rttpack: 60,
+                                dimm1_dqs_rttpark: 60,
+                                dram_drv: 34,
+                                ck_odt_a: 0,
+                                cs_odt_a: 0,
+                                ca_odt_a: 0,
+                                ck_odt_b: 40,
+                                cs_odt_b: 40,
+                                ca_odt_b: 60,
+                                p_odt: 60,
+                                dq_drv: 34,
+                                alert_pullup: 80,
+                                ca_drv: 40,
+                                phy_vref: 45,
+                                dq_vref: 45,
+                                ca_vref: 63,
+                                cs_vref: 56,
+                                d_ca_vref: 32,
+                                d_cs_vref: 40,
+                                rx_dfe: 1,
+                                tx_dfe: 1
+                              }
+                            },
+                            {
+                              header: {
+                                total_size: 12,
+                                target_memclk: 2000,
+                                dimm_slots_per_channel: 2,
+                                dimm0_rank_bitmap: 4,
+                                dimm1_rank_bitmap: 4,
+                                sdram_io_width_bitmap: 255
+                              },
+                              payload: {
+                                total_size: 124,
+                                ca_timing_mode: 1,
+                                dimm0_rttnomwr: 240,
+                                dimm0_rttnomrd: 48,
+                                dimm0_rttwr: 120,
+                                dimm0_rttpack: 48,
+                                dimm0_dqs_rttpark: 60,
+                                dimm1_rttnomwr: 240,
+                                dimm1_rttnomrd: 48,
+                                dimm1_rttwr: 120,
+                                dimm1_rttpack: 48,
+                                dimm1_dqs_rttpark: 60,
+                                dram_drv: 34,
+                                ck_odt_a: 0,
+                                cs_odt_a: 0,
+                                ca_odt_a: 0,
+                                ck_odt_b: 40,
+                                cs_odt_b: 40,
+                                ca_odt_b: 60,
+                                p_odt: 60,
+                                dq_drv: 34,
+                                alert_pullup: 80,
+                                ca_drv: 40,
+                                phy_vref: 45,
+                                dq_vref: 45,
+                                ca_vref: 63,
+                                cs_vref: 56,
+                                d_ca_vref: 32,
+                                d_cs_vref: 40,
+                                rx_dfe: 1,
+                                tx_dfe: 1
+                              }
+                            },
+                            {
+                              header: {
+                                total_size: 12,
+                                target_memclk: 2200,
+                                dimm_slots_per_channel: 2,
+                                dimm0_rank_bitmap: 4,
+                                dimm1_rank_bitmap: 4,
+                                sdram_io_width_bitmap: 1
+                              },
+                              payload: {
+                                total_size: 124,
+                                ca_timing_mode: 1,
+                                dimm0_rttnomwr: 120,
+                                dimm0_rttnomrd: 120,
+                                dimm0_rttwr: 240,
+                                dimm0_rttpack: 60,
+                                dimm0_dqs_rttpark: 60,
+                                dimm1_rttnomwr: 120,
+                                dimm1_rttnomrd: 120,
+                                dimm1_rttwr: 240,
+                                dimm1_rttpack: 60,
+                                dimm1_dqs_rttpark: 60,
+                                dram_drv: 34,
+                                ck_odt_a: 0,
+                                cs_odt_a: 0,
+                                ca_odt_a: 0,
+                                ck_odt_b: 40,
+                                cs_odt_b: 40,
+                                ca_odt_b: 60,
+                                p_odt: 60,
+                                dq_drv: 34,
+                                alert_pullup: 80,
+                                ca_drv: 40,
+                                phy_vref: 45,
+                                dq_vref: 45,
+                                ca_vref: 63,
+                                cs_vref: 56,
+                                d_ca_vref: 32,
+                                d_cs_vref: 40,
+                                rx_dfe: 1,
+                                tx_dfe: 1
+                              }
+                            },
+                            {
+                              header: {
+                                total_size: 12,
+                                target_memclk: 2200,
+                                dimm_slots_per_channel: 2,
+                                dimm0_rank_bitmap: 2,
+                                dimm1_rank_bitmap: 2,
+                                sdram_io_width_bitmap: 1
+                              },
+                              payload: {
+                                total_size: 124,
+                                ca_timing_mode: 1,
+                                dimm0_rttnomwr: 120,
+                                dimm0_rttnomrd: 34,
+                                dimm0_rttwr: 80,
+                                dimm0_rttpack: 34,
+                                dimm0_dqs_rttpark: 48,
+                                dimm1_rttnomwr: 120,
+                                dimm1_rttnomrd: 34,
+                                dimm1_rttwr: 80,
+                                dimm1_rttpack: 34,
+                                dimm1_dqs_rttpark: 48,
+                                dram_drv: 48,
+                                ck_odt_a: 0,
+                                cs_odt_a: 0,
+                                ca_odt_a: 0,
+                                ck_odt_b: 40,
+                                cs_odt_b: 40,
+                                ca_odt_b: 60,
+                                p_odt: 48,
+                                dq_drv: 34,
+                                alert_pullup: 80,
+                                ca_drv: 40,
+                                phy_vref: 45,
+                                dq_vref: 40,
+                                ca_vref: 63,
+                                cs_vref: 56,
+                                d_ca_vref: 32,
+                                d_cs_vref: 40,
+                                rx_dfe: 1,
+                                tx_dfe: 1
+                              }
+                            },
+                            {
+                              header: {
+                                total_size: 12,
+                                target_memclk: 2200,
+                                dimm_slots_per_channel: 2,
+                                dimm0_rank_bitmap: 2,
+                                dimm1_rank_bitmap: 2,
+                                sdram_io_width_bitmap: 2
+                              },
+                              payload: {
+                                total_size: 124,
+                                ca_timing_mode: 1,
+                                dimm0_rttnomwr: 120,
+                                dimm0_rttnomrd: 34,
+                                dimm0_rttwr: 80,
+                                dimm0_rttpack: 34,
+                                dimm0_dqs_rttpark: 48,
+                                dimm1_rttnomwr: 120,
+                                dimm1_rttnomrd: 34,
+                                dimm1_rttwr: 80,
+                                dimm1_rttpack: 34,
+                                dimm1_dqs_rttpark: 48,
+                                dram_drv: 34,
+                                ck_odt_a: 0,
+                                cs_odt_a: 0,
+                                ca_odt_a: 240,
+                                ck_odt_b: 40,
+                                cs_odt_b: 40,
+                                ca_odt_b: 60,
+                                p_odt: 48,
+                                dq_drv: 34,
+                                alert_pullup: 80,
+                                ca_drv: 40,
+                                phy_vref: 45,
+                                dq_vref: 40,
+                                ca_vref: 63,
+                                cs_vref: 56,
+                                d_ca_vref: 32,
+                                d_cs_vref: 40,
+                                rx_dfe: 1,
+                                tx_dfe: 1
+                              }
+                            },
+                            {
+                              header: {
+                                total_size: 12,
+                                target_memclk: 2600,
+                                dimm_slots_per_channel: 2,
+                                dimm0_rank_bitmap: 1,
+                                dimm1_rank_bitmap: 4,
+                                sdram_io_width_bitmap: 255
+                              },
+                              payload: {
+                                total_size: 124,
+                                ca_timing_mode: 1,
+                                dimm0_rttnomwr: 0,
+                                dimm0_rttnomrd: 0,
+                                dimm0_rttwr: 0,
+                                dimm0_rttpack: 0,
+                                dimm0_dqs_rttpark: 0,
+                                dimm1_rttnomwr: 0,
+                                dimm1_rttnomrd: 60,
+                                dimm1_rttwr: 120,
+                                dimm1_rttpack: 60,
+                                dimm1_dqs_rttpark: 60,
+                                dram_drv: 34,
+                                ck_odt_a: 0,
+                                cs_odt_a: 0,
+                                ca_odt_a: 0,
+                                ck_odt_b: 40,
+                                cs_odt_b: 40,
+                                ca_odt_b: 60,
+                                p_odt: 60,
+                                dq_drv: 34,
+                                alert_pullup: 80,
+                                ca_drv: 40,
+                                phy_vref: 45,
+                                dq_vref: 45,
+                                ca_vref: 63,
+                                cs_vref: 56,
+                                d_ca_vref: 48,
+                                d_cs_vref: 58,
+                                rx_dfe: 1,
+                                tx_dfe: 1
+                              }
+                            },
+                            {
+                              header: {
+                                total_size: 12,
+                                target_memclk: 3200,
+                                dimm_slots_per_channel: 1,
+                                dimm0_rank_bitmap: 2,
+                                dimm1_rank_bitmap: 1,
+                                sdram_io_width_bitmap: 1
+                              },
+                              payload: {
+                                total_size: 124,
+                                ca_timing_mode: 1,
+                                dimm0_rttnomwr: 0,
+                                dimm0_rttnomrd: 60,
+                                dimm0_rttwr: 60,
+                                dimm0_rttpack: 60,
+                                dimm0_dqs_rttpark: 60,
+                                dimm1_rttnomwr: 0,
+                                dimm1_rttnomrd: 0,
+                                dimm1_rttwr: 0,
+                                dimm1_rttpack: 0,
+                                dimm1_dqs_rttpark: 0,
+                                dram_drv: 34,
+                                ck_odt_a: 0,
+                                cs_odt_a: 0,
+                                ca_odt_a: 0,
+                                ck_odt_b: 40,
+                                cs_odt_b: 40,
+                                ca_odt_b: 60,
+                                p_odt: 48,
+                                dq_drv: 40,
+                                alert_pullup: 80,
+                                ca_drv: 40,
+                                phy_vref: 93,
+                                dq_vref: 40,
+                                ca_vref: 63,
+                                cs_vref: 56,
+                                d_ca_vref: 48,
+                                d_cs_vref: 58,
+                                rx_dfe: 1,
+                                tx_dfe: 1
+                              }
+                            },
+                            {
+                              header: {
+                                total_size: 12,
+                                target_memclk: 3200,
+                                dimm_slots_per_channel: 1,
+                                dimm0_rank_bitmap: 2,
+                                dimm1_rank_bitmap: 1,
+                                sdram_io_width_bitmap: 2
+                              },
+                              payload: {
+                                total_size: 124,
+                                ca_timing_mode: 1,
+                                dimm0_rttnomwr: 0,
+                                dimm0_rttnomrd: 60,
+                                dimm0_rttwr: 60,
+                                dimm0_rttpack: 60,
+                                dimm0_dqs_rttpark: 60,
+                                dimm1_rttnomwr: 0,
+                                dimm1_rttnomrd: 0,
+                                dimm1_rttwr: 0,
+                                dimm1_rttpack: 0,
+                                dimm1_dqs_rttpark: 0,
+                                dram_drv: 34,
+                                ck_odt_a: 0,
+                                cs_odt_a: 0,
+                                ca_odt_a: 240,
+                                ck_odt_b: 40,
+                                cs_odt_b: 40,
+                                ca_odt_b: 60,
+                                p_odt: 48,
+                                dq_drv: 40,
+                                alert_pullup: 80,
+                                ca_drv: 40,
+                                phy_vref: 93,
+                                dq_vref: 40,
+                                ca_vref: 63,
+                                cs_vref: 56,
+                                d_ca_vref: 48,
+                                d_cs_vref: 58,
+                                rx_dfe: 1,
+                                tx_dfe: 1
+                              }
+                            },
+                            {
+                              header: {
+                                total_size: 12,
+                                target_memclk: 3200,
+                                dimm_slots_per_channel: 1,
+                                dimm0_rank_bitmap: 4,
+                                dimm1_rank_bitmap: 1,
+                                sdram_io_width_bitmap: 255
+                              },
+                              payload: {
+                                total_size: 124,
+                                ca_timing_mode: 1,
+                                dimm0_rttnomwr: 0,
+                                dimm0_rttnomrd: 60,
+                                dimm0_rttwr: 120,
+                                dimm0_rttpack: 60,
+                                dimm0_dqs_rttpark: 60,
+                                dimm1_rttnomwr: 0,
+                                dimm1_rttnomrd: 0,
+                                dimm1_rttwr: 0,
+                                dimm1_rttpack: 0,
+                                dimm1_dqs_rttpark: 0,
+                                dram_drv: 34,
+                                ck_odt_a: 0,
+                                cs_odt_a: 0,
+                                ca_odt_a: 0,
+                                ck_odt_b: 40,
+                                cs_odt_b: 40,
+                                ca_odt_b: 60,
+                                p_odt: 60,
+                                dq_drv: 40,
+                                alert_pullup: 80,
+                                ca_drv: 40,
+                                phy_vref: 45,
+                                dq_vref: 45,
+                                ca_vref: 63,
+                                cs_vref: 56,
+                                d_ca_vref: 48,
+                                d_cs_vref: 58,
+                                rx_dfe: 1,
+                                tx_dfe: 1
+                              }
+                            },
+                            {
+                              header: {
+                                total_size: 12,
+                                target_memclk: 2600,
+                                dimm_slots_per_channel: 2,
+                                dimm0_rank_bitmap: 1,
+                                dimm1_rank_bitmap: 2,
+                                sdram_io_width_bitmap: 1
+                              },
+                              payload: {
+                                total_size: 124,
+                                ca_timing_mode: 1,
+                                dimm0_rttnomwr: 0,
+                                dimm0_rttnomrd: 0,
+                                dimm0_rttwr: 0,
+                                dimm0_rttpack: 0,
+                                dimm0_dqs_rttpark: 0,
+                                dimm1_rttnomwr: 0,
+                                dimm1_rttnomrd: 60,
+                                dimm1_rttwr: 60,
+                                dimm1_rttpack: 60,
+                                dimm1_dqs_rttpark: 60,
+                                dram_drv: 34,
+                                ck_odt_a: 0,
+                                cs_odt_a: 0,
+                                ca_odt_a: 0,
+                                ck_odt_b: 40,
+                                cs_odt_b: 40,
+                                ca_odt_b: 60,
+                                p_odt: 48,
+                                dq_drv: 34,
+                                alert_pullup: 80,
+                                ca_drv: 40,
+                                phy_vref: 93,
+                                dq_vref: 40,
+                                ca_vref: 63,
+                                cs_vref: 56,
+                                d_ca_vref: 48,
+                                d_cs_vref: 58,
+                                rx_dfe: 1,
+                                tx_dfe: 1
+                              }
+                            },
+                            {
+                              header: {
+                                total_size: 12,
+                                target_memclk: 2600,
+                                dimm_slots_per_channel: 2,
+                                dimm0_rank_bitmap: 1,
+                                dimm1_rank_bitmap: 2,
+                                sdram_io_width_bitmap: 2
+                              },
+                              payload: {
+                                total_size: 124,
+                                ca_timing_mode: 1,
+                                dimm0_rttnomwr: 0,
+                                dimm0_rttnomrd: 0,
+                                dimm0_rttwr: 0,
+                                dimm0_rttpack: 0,
+                                dimm0_dqs_rttpark: 0,
+                                dimm1_rttnomwr: 0,
+                                dimm1_rttnomrd: 60,
+                                dimm1_rttwr: 60,
+                                dimm1_rttpack: 60,
+                                dimm1_dqs_rttpark: 60,
+                                dram_drv: 34,
+                                ck_odt_a: 0,
+                                cs_odt_a: 0,
+                                ca_odt_a: 240,
+                                ck_odt_b: 40,
+                                cs_odt_b: 40,
+                                ca_odt_b: 60,
+                                p_odt: 48,
+                                dq_drv: 34,
+                                alert_pullup: 80,
+                                ca_drv: 40,
+                                phy_vref: 93,
+                                dq_vref: 40,
+                                ca_vref: 63,
+                                cs_vref: 56,
+                                d_ca_vref: 48,
+                                d_cs_vref: 58,
+                                rx_dfe: 1,
+                                tx_dfe: 1
+                              }
+                            }
+                          ]
+                        },
+                        {
+                          header: {
+                            group_id: 5892,
+                            entry_id: 137,
+                            instance_id: 52868,
+                            context_type: "Struct",
+                            context_format: "Raw",
+                            unit_size: 0,
+                            priority_mask: {
+                              hard_force: false,
+                              high: false,
+                              medium: false,
+                              event_logging: false,
+                              low: false,
+                              normal: true,
+                            },
+                            key_size: 0,
+                            key_pos: 0,
+                            board_instance_mask: 65535
+                          },
+                          RdimmDdr5BusElement: [
+                            {
+                              header: {
+                                total_size: 12,
+                                target_memclk: 1800,
+                                dimm_slots_per_channel: 2,
+                                dimm0_rank_bitmap: 4,
+                                dimm1_rank_bitmap: 4,
+                                sdram_io_width_bitmap: 255
+                              },
+                              payload: {
+                                total_size: 124,
+                                ca_timing_mode: 1,
+                                dimm0_rttnomwr: 240,
+                                dimm0_rttnomrd: 60,
+                                dimm0_rttwr: 240,
+                                dimm0_rttpack: 60,
+                                dimm0_dqs_rttpark: 60,
+                                dimm1_rttnomwr: 240,
+                                dimm1_rttnomrd: 60,
+                                dimm1_rttwr: 240,
+                                dimm1_rttpack: 60,
+                                dimm1_dqs_rttpark: 60,
+                                dram_drv: 34,
+                                ck_odt_a: 0,
+                                cs_odt_a: 0,
+                                ca_odt_a: 0,
+                                ck_odt_b: 40,
+                                cs_odt_b: 40,
+                                ca_odt_b: 60,
+                                p_odt: 60,
+                                dq_drv: 34,
+                                alert_pullup: 80,
+                                ca_drv: 40,
+                                phy_vref: 45,
+                                dq_vref: 45,
+                                ca_vref: 63,
+                                cs_vref: 56,
+                                d_ca_vref: 32,
+                                d_cs_vref: 40,
+                                rx_dfe: 1,
+                                tx_dfe: 1
+                              }
+                            },
+                            {
+                              header: {
+                                total_size: 12,
+                                target_memclk: 2000,
+                                dimm_slots_per_channel: 2,
+                                dimm0_rank_bitmap: 4,
+                                dimm1_rank_bitmap: 4,
+                                sdram_io_width_bitmap: 255
+                              },
+                              payload: {
+                                total_size: 124,
+                                ca_timing_mode: 1,
+                                dimm0_rttnomwr: 240,
+                                dimm0_rttnomrd: 48,
+                                dimm0_rttwr: 120,
+                                dimm0_rttpack: 48,
+                                dimm0_dqs_rttpark: 60,
+                                dimm1_rttnomwr: 240,
+                                dimm1_rttnomrd: 48,
+                                dimm1_rttwr: 120,
+                                dimm1_rttpack: 48,
+                                dimm1_dqs_rttpark: 60,
+                                dram_drv: 34,
+                                ck_odt_a: 0,
+                                cs_odt_a: 0,
+                                ca_odt_a: 0,
+                                ck_odt_b: 40,
+                                cs_odt_b: 40,
+                                ca_odt_b: 60,
+                                p_odt: 60,
+                                dq_drv: 34,
+                                alert_pullup: 80,
+                                ca_drv: 40,
+                                phy_vref: 45,
+                                dq_vref: 45,
+                                ca_vref: 63,
+                                cs_vref: 56,
+                                d_ca_vref: 32,
+                                d_cs_vref: 40,
+                                rx_dfe: 1,
+                                tx_dfe: 1
+                              }
+                            },
+                            {
+                              header: {
+                                total_size: 12,
+                                target_memclk: 2200,
+                                dimm_slots_per_channel: 2,
+                                dimm0_rank_bitmap: 4,
+                                dimm1_rank_bitmap: 4,
+                                sdram_io_width_bitmap: 1
+                              },
+                              payload: {
+                                total_size: 124,
+                                ca_timing_mode: 1,
+                                dimm0_rttnomwr: 120,
+                                dimm0_rttnomrd: 120,
+                                dimm0_rttwr: 240,
+                                dimm0_rttpack: 60,
+                                dimm0_dqs_rttpark: 60,
+                                dimm1_rttnomwr: 120,
+                                dimm1_rttnomrd: 120,
+                                dimm1_rttwr: 240,
+                                dimm1_rttpack: 60,
+                                dimm1_dqs_rttpark: 60,
+                                dram_drv: 34,
+                                ck_odt_a: 0,
+                                cs_odt_a: 0,
+                                ca_odt_a: 0,
+                                ck_odt_b: 40,
+                                cs_odt_b: 40,
+                                ca_odt_b: 60,
+                                p_odt: 60,
+                                dq_drv: 34,
+                                alert_pullup: 80,
+                                ca_drv: 40,
+                                phy_vref: 45,
+                                dq_vref: 45,
+                                ca_vref: 63,
+                                cs_vref: 56,
+                                d_ca_vref: 32,
+                                d_cs_vref: 40,
+                                rx_dfe: 1,
+                                tx_dfe: 1
+                              }
+                            },
+                            {
+                              header: {
+                                total_size: 12,
+                                target_memclk: 2200,
+                                dimm_slots_per_channel: 2,
+                                dimm0_rank_bitmap: 2,
+                                dimm1_rank_bitmap: 2,
+                                sdram_io_width_bitmap: 1
+                              },
+                              payload: {
+                                total_size: 124,
+                                ca_timing_mode: 1,
+                                dimm0_rttnomwr: 120,
+                                dimm0_rttnomrd: 34,
+                                dimm0_rttwr: 80,
+                                dimm0_rttpack: 34,
+                                dimm0_dqs_rttpark: 48,
+                                dimm1_rttnomwr: 120,
+                                dimm1_rttnomrd: 34,
+                                dimm1_rttwr: 80,
+                                dimm1_rttpack: 34,
+                                dimm1_dqs_rttpark: 48,
+                                dram_drv: 34,
+                                ck_odt_a: 0,
+                                cs_odt_a: 0,
+                                ca_odt_a: 0,
+                                ck_odt_b: 40,
+                                cs_odt_b: 40,
+                                ca_odt_b: 60,
+                                p_odt: 48,
+                                dq_drv: 34,
+                                alert_pullup: 80,
+                                ca_drv: 40,
+                                phy_vref: 45,
+                                dq_vref: 40,
+                                ca_vref: 63,
+                                cs_vref: 56,
+                                d_ca_vref: 32,
+                                d_cs_vref: 40,
+                                rx_dfe: 1,
+                                tx_dfe: 1
+                              }
+                            },
+                            {
+                              header: {
+                                total_size: 12,
+                                target_memclk: 2200,
+                                dimm_slots_per_channel: 2,
+                                dimm0_rank_bitmap: 2,
+                                dimm1_rank_bitmap: 2,
+                                sdram_io_width_bitmap: 2
+                              },
+                              payload: {
+                                total_size: 124,
+                                ca_timing_mode: 1,
+                                dimm0_rttnomwr: 120,
+                                dimm0_rttnomrd: 34,
+                                dimm0_rttwr: 80,
+                                dimm0_rttpack: 34,
+                                dimm0_dqs_rttpark: 48,
+                                dimm1_rttnomwr: 120,
+                                dimm1_rttnomrd: 34,
+                                dimm1_rttwr: 80,
+                                dimm1_rttpack: 34,
+                                dimm1_dqs_rttpark: 48,
+                                dram_drv: 34,
+                                ck_odt_a: 0,
+                                cs_odt_a: 0,
+                                ca_odt_a: 240,
+                                ck_odt_b: 40,
+                                cs_odt_b: 40,
+                                ca_odt_b: 60,
+                                p_odt: 48,
+                                dq_drv: 34,
+                                alert_pullup: 80,
+                                ca_drv: 40,
+                                phy_vref: 45,
+                                dq_vref: 40,
+                                ca_vref: 63,
+                                cs_vref: 56,
+                                d_ca_vref: 32,
+                                d_cs_vref: 40,
+                                rx_dfe: 1,
+                                tx_dfe: 1
+                              }
+                            },
+                            {
+                              header: {
+                                total_size: 12,
+                                target_memclk: 2600,
+                                dimm_slots_per_channel: 2,
+                                dimm0_rank_bitmap: 1,
+                                dimm1_rank_bitmap: 4,
+                                sdram_io_width_bitmap: 255
+                              },
+                              payload: {
+                                total_size: 124,
+                                ca_timing_mode: 1,
+                                dimm0_rttnomwr: 0,
+                                dimm0_rttnomrd: 0,
+                                dimm0_rttwr: 0,
+                                dimm0_rttpack: 0,
+                                dimm0_dqs_rttpark: 0,
+                                dimm1_rttnomwr: 0,
+                                dimm1_rttnomrd: 60,
+                                dimm1_rttwr: 120,
+                                dimm1_rttpack: 60,
+                                dimm1_dqs_rttpark: 60,
+                                dram_drv: 34,
+                                ck_odt_a: 0,
+                                cs_odt_a: 0,
+                                ca_odt_a: 0,
+                                ck_odt_b: 40,
+                                cs_odt_b: 40,
+                                ca_odt_b: 60,
+                                p_odt: 60,
+                                dq_drv: 34,
+                                alert_pullup: 80,
+                                ca_drv: 40,
+                                phy_vref: 45,
+                                dq_vref: 45,
+                                ca_vref: 63,
+                                cs_vref: 56,
+                                d_ca_vref: 48,
+                                d_cs_vref: 58,
+                                rx_dfe: 1,
+                                tx_dfe: 1
+                              }
+                            },
+                            {
+                              header: {
+                                total_size: 12,
+                                target_memclk: 3200,
+                                dimm_slots_per_channel: 1,
+                                dimm0_rank_bitmap: 2,
+                                dimm1_rank_bitmap: 1,
+                                sdram_io_width_bitmap: 1
+                              },
+                              payload: {
+                                total_size: 124,
+                                ca_timing_mode: 1,
+                                dimm0_rttnomwr: 0,
+                                dimm0_rttnomrd: 60,
+                                dimm0_rttwr: 60,
+                                dimm0_rttpack: 60,
+                                dimm0_dqs_rttpark: 60,
+                                dimm1_rttnomwr: 0,
+                                dimm1_rttnomrd: 0,
+                                dimm1_rttwr: 0,
+                                dimm1_rttpack: 0,
+                                dimm1_dqs_rttpark: 0,
+                                dram_drv: 34,
+                                ck_odt_a: 0,
+                                cs_odt_a: 0,
+                                ca_odt_a: 0,
+                                ck_odt_b: 40,
+                                cs_odt_b: 40,
+                                ca_odt_b: 60,
+                                p_odt: 48,
+                                dq_drv: 40,
+                                alert_pullup: 80,
+                                ca_drv: 40,
+                                phy_vref: 93,
+                                dq_vref: 40,
+                                ca_vref: 63,
+                                cs_vref: 56,
+                                d_ca_vref: 48,
+                                d_cs_vref: 58,
+                                rx_dfe: 1,
+                                tx_dfe: 1
+                              }
+                            },
+                            {
+                              header: {
+                                total_size: 12,
+                                target_memclk: 3200,
+                                dimm_slots_per_channel: 1,
+                                dimm0_rank_bitmap: 2,
+                                dimm1_rank_bitmap: 1,
+                                sdram_io_width_bitmap: 2
+                              },
+                              payload: {
+                                total_size: 124,
+                                ca_timing_mode: 1,
+                                dimm0_rttnomwr: 0,
+                                dimm0_rttnomrd: 60,
+                                dimm0_rttwr: 60,
+                                dimm0_rttpack: 60,
+                                dimm0_dqs_rttpark: 60,
+                                dimm1_rttnomwr: 0,
+                                dimm1_rttnomrd: 0,
+                                dimm1_rttwr: 0,
+                                dimm1_rttpack: 0,
+                                dimm1_dqs_rttpark: 0,
+                                dram_drv: 34,
+                                ck_odt_a: 0,
+                                cs_odt_a: 0,
+                                ca_odt_a: 240,
+                                ck_odt_b: 40,
+                                cs_odt_b: 40,
+                                ca_odt_b: 60,
+                                p_odt: 48,
+                                dq_drv: 40,
+                                alert_pullup: 80,
+                                ca_drv: 40,
+                                phy_vref: 93,
+                                dq_vref: 40,
+                                ca_vref: 63,
+                                cs_vref: 56,
+                                d_ca_vref: 48,
+                                d_cs_vref: 58,
+                                rx_dfe: 1,
+                                tx_dfe: 1
+                              }
+                            },
+                            {
+                              header: {
+                                total_size: 12,
+                                target_memclk: 3200,
+                                dimm_slots_per_channel: 1,
+                                dimm0_rank_bitmap: 4,
+                                dimm1_rank_bitmap: 1,
+                                sdram_io_width_bitmap: 255
+                              },
+                              payload: {
+                                total_size: 124,
+                                ca_timing_mode: 1,
+                                dimm0_rttnomwr: 0,
+                                dimm0_rttnomrd: 60,
+                                dimm0_rttwr: 120,
+                                dimm0_rttpack: 60,
+                                dimm0_dqs_rttpark: 60,
+                                dimm1_rttnomwr: 0,
+                                dimm1_rttnomrd: 0,
+                                dimm1_rttwr: 0,
+                                dimm1_rttpack: 0,
+                                dimm1_dqs_rttpark: 0,
+                                dram_drv: 34,
+                                ck_odt_a: 0,
+                                cs_odt_a: 0,
+                                ca_odt_a: 0,
+                                ck_odt_b: 40,
+                                cs_odt_b: 40,
+                                ca_odt_b: 60,
+                                p_odt: 60,
+                                dq_drv: 40,
+                                alert_pullup: 80,
+                                ca_drv: 40,
+                                phy_vref: 45,
+                                dq_vref: 45,
+                                ca_vref: 63,
+                                cs_vref: 56,
+                                d_ca_vref: 48,
+                                d_cs_vref: 58,
+                                rx_dfe: 1,
+                                tx_dfe: 1
+                              }
+                            },
+                            {
+                              header: {
+                                total_size: 12,
+                                target_memclk: 2600,
+                                dimm_slots_per_channel: 2,
+                                dimm0_rank_bitmap: 1,
+                                dimm1_rank_bitmap: 2,
+                                sdram_io_width_bitmap: 1
+                              },
+                              payload: {
+                                total_size: 124,
+                                ca_timing_mode: 1,
+                                dimm0_rttnomwr: 0,
+                                dimm0_rttnomrd: 0,
+                                dimm0_rttwr: 0,
+                                dimm0_rttpack: 0,
+                                dimm0_dqs_rttpark: 0,
+                                dimm1_rttnomwr: 0,
+                                dimm1_rttnomrd: 60,
+                                dimm1_rttwr: 60,
+                                dimm1_rttpack: 60,
+                                dimm1_dqs_rttpark: 60,
+                                dram_drv: 34,
+                                ck_odt_a: 0,
+                                cs_odt_a: 0,
+                                ca_odt_a: 0,
+                                ck_odt_b: 40,
+                                cs_odt_b: 40,
+                                ca_odt_b: 60,
+                                p_odt: 48,
+                                dq_drv: 34,
+                                alert_pullup: 80,
+                                ca_drv: 40,
+                                phy_vref: 93,
+                                dq_vref: 40,
+                                ca_vref: 63,
+                                cs_vref: 56,
+                                d_ca_vref: 48,
+                                d_cs_vref: 58,
+                                rx_dfe: 1,
+                                tx_dfe: 1
+                              }
+                            },
+                            {
+                              header: {
+                                total_size: 12,
+                                target_memclk: 2600,
+                                dimm_slots_per_channel: 2,
+                                dimm0_rank_bitmap: 1,
+                                dimm1_rank_bitmap: 2,
+                                sdram_io_width_bitmap: 2
+                              },
+                              payload: {
+                                total_size: 124,
+                                ca_timing_mode: 1,
+                                dimm0_rttnomwr: 0,
+                                dimm0_rttnomrd: 0,
+                                dimm0_rttwr: 0,
+                                dimm0_rttpack: 0,
+                                dimm0_dqs_rttpark: 0,
+                                dimm1_rttnomwr: 0,
+                                dimm1_rttnomrd: 60,
+                                dimm1_rttwr: 60,
+                                dimm1_rttpack: 60,
+                                dimm1_dqs_rttpark: 60,
+                                dram_drv: 34,
+                                ck_odt_a: 0,
+                                cs_odt_a: 0,
+                                ca_odt_a: 240,
+                                ck_odt_b: 40,
+                                cs_odt_b: 40,
+                                ca_odt_b: 60,
+                                p_odt: 48,
+                                dq_drv: 34,
+                                alert_pullup: 80,
+                                ca_drv: 40,
+                                phy_vref: 93,
+                                dq_vref: 40,
+                                ca_vref: 63,
+                                cs_vref: 56,
+                                d_ca_vref: 48,
+                                d_cs_vref: 58,
+                                rx_dfe: 1,
+                                tx_dfe: 1
+                              }
+                            }
+                          ]
+                        },
+                        {
+                          header: {
+                            group_id: 5892,
+                            entry_id: 137,
+                            instance_id: 52870,
+                            context_type: "Struct",
+                            context_format: "Raw",
+                            unit_size: 0,
+                            priority_mask: {
+                              hard_force: false,
+                              high: false,
+                              medium: false,
+                              event_logging: false,
+                              low: false,
+                              normal: true,
+                            },
+                            key_size: 0,
+                            key_pos: 0,
+                            board_instance_mask: 65535
+                          },
+                          RdimmDdr5BusElement: [
+                            {
+                              header: {
+                                total_size: 12,
+                                target_memclk: 2000,
+                                dimm_slots_per_channel: 2,
+                                dimm0_rank_bitmap: 4,
+                                dimm1_rank_bitmap: 4,
+                                sdram_io_width_bitmap: 255
+                              },
+                              payload: {
+                                total_size: 124,
+                                ca_timing_mode: 1,
+                                dimm0_rttnomwr: 240,
+                                dimm0_rttnomrd: 60,
+                                dimm0_rttwr: 240,
+                                dimm0_rttpack: 60,
+                                dimm0_dqs_rttpark: 60,
+                                dimm1_rttnomwr: 240,
+                                dimm1_rttnomrd: 60,
+                                dimm1_rttwr: 240,
+                                dimm1_rttpack: 60,
+                                dimm1_dqs_rttpark: 60,
+                                dram_drv: 34,
+                                ck_odt_a: 0,
+                                cs_odt_a: 0,
+                                ca_odt_a: 0,
+                                ck_odt_b: 40,
+                                cs_odt_b: 40,
+                                ca_odt_b: 60,
+                                p_odt: 60,
+                                dq_drv: 34,
+                                alert_pullup: 80,
+                                ca_drv: 40,
+                                phy_vref: 45,
+                                dq_vref: 45,
+                                ca_vref: 63,
+                                cs_vref: 56,
+                                d_ca_vref: 32,
+                                d_cs_vref: 40,
+                                rx_dfe: 1,
+                                tx_dfe: 1
+                              }
+                            },
+                            {
+                              header: {
+                                total_size: 12,
+                                target_memclk: 2200,
+                                dimm_slots_per_channel: 2,
+                                dimm0_rank_bitmap: 4,
+                                dimm1_rank_bitmap: 4,
+                                sdram_io_width_bitmap: 1
+                              },
+                              payload: {
+                                total_size: 124,
+                                ca_timing_mode: 1,
+                                dimm0_rttnomwr: 120,
+                                dimm0_rttnomrd: 120,
+                                dimm0_rttwr: 240,
+                                dimm0_rttpack: 60,
+                                dimm0_dqs_rttpark: 60,
+                                dimm1_rttnomwr: 120,
+                                dimm1_rttnomrd: 120,
+                                dimm1_rttwr: 240,
+                                dimm1_rttpack: 60,
+                                dimm1_dqs_rttpark: 60,
+                                dram_drv: 34,
+                                ck_odt_a: 0,
+                                cs_odt_a: 0,
+                                ca_odt_a: 0,
+                                ck_odt_b: 40,
+                                cs_odt_b: 40,
+                                ca_odt_b: 60,
+                                p_odt: 60,
+                                dq_drv: 34,
+                                alert_pullup: 80,
+                                ca_drv: 40,
+                                phy_vref: 45,
+                                dq_vref: 45,
+                                ca_vref: 63,
+                                cs_vref: 56,
+                                d_ca_vref: 32,
+                                d_cs_vref: 40,
+                                rx_dfe: 1,
+                                tx_dfe: 1
+                              }
+                            },
+                            {
+                              header: {
+                                total_size: 12,
+                                target_memclk: 2200,
+                                dimm_slots_per_channel: 2,
+                                dimm0_rank_bitmap: 2,
+                                dimm1_rank_bitmap: 2,
+                                sdram_io_width_bitmap: 1
+                              },
+                              payload: {
+                                total_size: 124,
+                                ca_timing_mode: 1,
+                                dimm0_rttnomwr: 120,
+                                dimm0_rttnomrd: 34,
+                                dimm0_rttwr: 80,
+                                dimm0_rttpack: 34,
+                                dimm0_dqs_rttpark: 48,
+                                dimm1_rttnomwr: 120,
+                                dimm1_rttnomrd: 34,
+                                dimm1_rttwr: 80,
+                                dimm1_rttpack: 34,
+                                dimm1_dqs_rttpark: 48,
+                                dram_drv: 34,
+                                ck_odt_a: 0,
+                                cs_odt_a: 0,
+                                ca_odt_a: 0,
+                                ck_odt_b: 40,
+                                cs_odt_b: 40,
+                                ca_odt_b: 60,
+                                p_odt: 48,
+                                dq_drv: 34,
+                                alert_pullup: 80,
+                                ca_drv: 40,
+                                phy_vref: 45,
+                                dq_vref: 40,
+                                ca_vref: 63,
+                                cs_vref: 56,
+                                d_ca_vref: 32,
+                                d_cs_vref: 40,
+                                rx_dfe: 1,
+                                tx_dfe: 1
+                              }
+                            },
+                            {
+                              header: {
+                                total_size: 12,
+                                target_memclk: 2200,
+                                dimm_slots_per_channel: 2,
+                                dimm0_rank_bitmap: 2,
+                                dimm1_rank_bitmap: 2,
+                                sdram_io_width_bitmap: 2
+                              },
+                              payload: {
+                                total_size: 124,
+                                ca_timing_mode: 1,
+                                dimm0_rttnomwr: 120,
+                                dimm0_rttnomrd: 34,
+                                dimm0_rttwr: 80,
+                                dimm0_rttpack: 34,
+                                dimm0_dqs_rttpark: 48,
+                                dimm1_rttnomwr: 120,
+                                dimm1_rttnomrd: 34,
+                                dimm1_rttwr: 80,
+                                dimm1_rttpack: 34,
+                                dimm1_dqs_rttpark: 48,
+                                dram_drv: 34,
+                                ck_odt_a: 0,
+                                cs_odt_a: 0,
+                                ca_odt_a: 240,
+                                ck_odt_b: 40,
+                                cs_odt_b: 40,
+                                ca_odt_b: 60,
+                                p_odt: 48,
+                                dq_drv: 34,
+                                alert_pullup: 80,
+                                ca_drv: 40,
+                                phy_vref: 45,
+                                dq_vref: 40,
+                                ca_vref: 63,
+                                cs_vref: 56,
+                                d_ca_vref: 32,
+                                d_cs_vref: 40,
+                                rx_dfe: 1,
+                                tx_dfe: 1
+                              }
+                            },
+                            {
+                              header: {
+                                total_size: 12,
+                                target_memclk: 2600,
+                                dimm_slots_per_channel: 2,
+                                dimm0_rank_bitmap: 1,
+                                dimm1_rank_bitmap: 4,
+                                sdram_io_width_bitmap: 255
+                              },
+                              payload: {
+                                total_size: 124,
+                                ca_timing_mode: 1,
+                                dimm0_rttnomwr: 0,
+                                dimm0_rttnomrd: 0,
+                                dimm0_rttwr: 0,
+                                dimm0_rttpack: 0,
+                                dimm0_dqs_rttpark: 0,
+                                dimm1_rttnomwr: 0,
+                                dimm1_rttnomrd: 60,
+                                dimm1_rttwr: 120,
+                                dimm1_rttpack: 60,
+                                dimm1_dqs_rttpark: 60,
+                                dram_drv: 34,
+                                ck_odt_a: 0,
+                                cs_odt_a: 0,
+                                ca_odt_a: 0,
+                                ck_odt_b: 40,
+                                cs_odt_b: 40,
+                                ca_odt_b: 60,
+                                p_odt: 60,
+                                dq_drv: 34,
+                                alert_pullup: 80,
+                                ca_drv: 40,
+                                phy_vref: 45,
+                                dq_vref: 45,
+                                ca_vref: 63,
+                                cs_vref: 56,
+                                d_ca_vref: 48,
+                                d_cs_vref: 58,
+                                rx_dfe: 1,
+                                tx_dfe: 1
+                              }
+                            },
+                            {
+                              header: {
+                                total_size: 12,
+                                target_memclk: 3200,
+                                dimm_slots_per_channel: 1,
+                                dimm0_rank_bitmap: 2,
+                                dimm1_rank_bitmap: 1,
+                                sdram_io_width_bitmap: 1
+                              },
+                              payload: {
+                                total_size: 124,
+                                ca_timing_mode: 1,
+                                dimm0_rttnomwr: 0,
+                                dimm0_rttnomrd: 60,
+                                dimm0_rttwr: 60,
+                                dimm0_rttpack: 60,
+                                dimm0_dqs_rttpark: 60,
+                                dimm1_rttnomwr: 0,
+                                dimm1_rttnomrd: 0,
+                                dimm1_rttwr: 0,
+                                dimm1_rttpack: 0,
+                                dimm1_dqs_rttpark: 0,
+                                dram_drv: 34,
+                                ck_odt_a: 0,
+                                cs_odt_a: 0,
+                                ca_odt_a: 0,
+                                ck_odt_b: 40,
+                                cs_odt_b: 40,
+                                ca_odt_b: 60,
+                                p_odt: 48,
+                                dq_drv: 40,
+                                alert_pullup: 80,
+                                ca_drv: 40,
+                                phy_vref: 93,
+                                dq_vref: 40,
+                                ca_vref: 63,
+                                cs_vref: 56,
+                                d_ca_vref: 48,
+                                d_cs_vref: 58,
+                                rx_dfe: 1,
+                                tx_dfe: 1
+                              }
+                            },
+                            {
+                              header: {
+                                total_size: 12,
+                                target_memclk: 3200,
+                                dimm_slots_per_channel: 1,
+                                dimm0_rank_bitmap: 2,
+                                dimm1_rank_bitmap: 1,
+                                sdram_io_width_bitmap: 2
+                              },
+                              payload: {
+                                total_size: 124,
+                                ca_timing_mode: 1,
+                                dimm0_rttnomwr: 0,
+                                dimm0_rttnomrd: 60,
+                                dimm0_rttwr: 60,
+                                dimm0_rttpack: 60,
+                                dimm0_dqs_rttpark: 60,
+                                dimm1_rttnomwr: 0,
+                                dimm1_rttnomrd: 0,
+                                dimm1_rttwr: 0,
+                                dimm1_rttpack: 0,
+                                dimm1_dqs_rttpark: 0,
+                                dram_drv: 34,
+                                ck_odt_a: 0,
+                                cs_odt_a: 0,
+                                ca_odt_a: 240,
+                                ck_odt_b: 40,
+                                cs_odt_b: 40,
+                                ca_odt_b: 60,
+                                p_odt: 48,
+                                dq_drv: 40,
+                                alert_pullup: 80,
+                                ca_drv: 40,
+                                phy_vref: 93,
+                                dq_vref: 40,
+                                ca_vref: 63,
+                                cs_vref: 56,
+                                d_ca_vref: 48,
+                                d_cs_vref: 58,
+                                rx_dfe: 1,
+                                tx_dfe: 1
+                              }
+                            },
+                            {
+                              header: {
+                                total_size: 12,
+                                target_memclk: 3200,
+                                dimm_slots_per_channel: 1,
+                                dimm0_rank_bitmap: 4,
+                                dimm1_rank_bitmap: 1,
+                                sdram_io_width_bitmap: 1
+                              },
+                              payload: {
+                                total_size: 124,
+                                ca_timing_mode: 1,
+                                dimm0_rttnomwr: 0,
+                                dimm0_rttnomrd: 40,
+                                dimm0_rttwr: 240,
+                                dimm0_rttpack: 40,
+                                dimm0_dqs_rttpark: 40,
+                                dimm1_rttnomwr: 0,
+                                dimm1_rttnomrd: 0,
+                                dimm1_rttwr: 0,
+                                dimm1_rttpack: 0,
+                                dimm1_dqs_rttpark: 0,
+                                dram_drv: 34,
+                                ck_odt_a: 0,
+                                cs_odt_a: 0,
+                                ca_odt_a: 0,
+                                ck_odt_b: 40,
+                                cs_odt_b: 40,
+                                ca_odt_b: 60,
+                                p_odt: 53,
+                                dq_drv: 34,
+                                alert_pullup: 80,
+                                ca_drv: 40,
+                                phy_vref: 45,
+                                dq_vref: 45,
+                                ca_vref: 63,
+                                cs_vref: 56,
+                                d_ca_vref: 48,
+                                d_cs_vref: 58,
+                                rx_dfe: 1,
+                                tx_dfe: 1
+                              }
+                            },
+                            {
+                              header: {
+                                total_size: 12,
+                                target_memclk: 3200,
+                                dimm_slots_per_channel: 1,
+                                dimm0_rank_bitmap: 4,
+                                dimm1_rank_bitmap: 1,
+                                sdram_io_width_bitmap: 2
+                              },
+                              payload: {
+                                total_size: 124,
+                                ca_timing_mode: 1,
+                                dimm0_rttnomwr: 0,
+                                dimm0_rttnomrd: 40,
+                                dimm0_rttwr: 120,
+                                dimm0_rttpack: 40,
+                                dimm0_dqs_rttpark: 40,
+                                dimm1_rttnomwr: 0,
+                                dimm1_rttnomrd: 0,
+                                dimm1_rttwr: 0,
+                                dimm1_rttpack: 0,
+                                dimm1_dqs_rttpark: 0,
+                                dram_drv: 34,
+                                ck_odt_a: 0,
+                                cs_odt_a: 0,
+                                ca_odt_a: 0,
+                                ck_odt_b: 40,
+                                cs_odt_b: 40,
+                                ca_odt_b: 60,
+                                p_odt: 53,
+                                dq_drv: 34,
+                                alert_pullup: 80,
+                                ca_drv: 40,
+                                phy_vref: 45,
+                                dq_vref: 45,
+                                ca_vref: 63,
+                                cs_vref: 56,
+                                d_ca_vref: 48,
+                                d_cs_vref: 58,
+                                rx_dfe: 1,
+                                tx_dfe: 1
+                              }
+                            },
+                            {
+                              header: {
+                                total_size: 12,
+                                target_memclk: 2600,
+                                dimm_slots_per_channel: 2,
+                                dimm0_rank_bitmap: 1,
+                                dimm1_rank_bitmap: 2,
+                                sdram_io_width_bitmap: 1
+                              },
+                              payload: {
+                                total_size: 124,
+                                ca_timing_mode: 1,
+                                dimm0_rttnomwr: 0,
+                                dimm0_rttnomrd: 0,
+                                dimm0_rttwr: 0,
+                                dimm0_rttpack: 0,
+                                dimm0_dqs_rttpark: 0,
+                                dimm1_rttnomwr: 0,
+                                dimm1_rttnomrd: 60,
+                                dimm1_rttwr: 60,
+                                dimm1_rttpack: 60,
+                                dimm1_dqs_rttpark: 60,
+                                dram_drv: 34,
+                                ck_odt_a: 0,
+                                cs_odt_a: 0,
+                                ca_odt_a: 0,
+                                ck_odt_b: 40,
+                                cs_odt_b: 40,
+                                ca_odt_b: 60,
+                                p_odt: 48,
+                                dq_drv: 34,
+                                alert_pullup: 80,
+                                ca_drv: 40,
+                                phy_vref: 93,
+                                dq_vref: 40,
+                                ca_vref: 63,
+                                cs_vref: 56,
+                                d_ca_vref: 48,
+                                d_cs_vref: 58,
+                                rx_dfe: 1,
+                                tx_dfe: 1
+                              }
+                            },
+                            {
+                              header: {
+                                total_size: 12,
+                                target_memclk: 2600,
+                                dimm_slots_per_channel: 2,
+                                dimm0_rank_bitmap: 1,
+                                dimm1_rank_bitmap: 2,
+                                sdram_io_width_bitmap: 2
+                              },
+                              payload: {
+                                total_size: 124,
+                                ca_timing_mode: 1,
+                                dimm0_rttnomwr: 0,
+                                dimm0_rttnomrd: 0,
+                                dimm0_rttwr: 0,
+                                dimm0_rttpack: 0,
+                                dimm0_dqs_rttpark: 0,
+                                dimm1_rttnomwr: 0,
+                                dimm1_rttnomrd: 60,
+                                dimm1_rttwr: 60,
+                                dimm1_rttpack: 60,
+                                dimm1_dqs_rttpark: 60,
+                                dram_drv: 34,
+                                ck_odt_a: 0,
+                                cs_odt_a: 0,
+                                ca_odt_a: 240,
+                                ck_odt_b: 40,
+                                cs_odt_b: 40,
+                                ca_odt_b: 60,
+                                p_odt: 48,
+                                dq_drv: 34,
+                                alert_pullup: 80,
+                                ca_drv: 40,
+                                phy_vref: 93,
+                                dq_vref: 40,
+                                ca_vref: 63,
+                                cs_vref: 56,
+                                d_ca_vref: 48,
+                                d_cs_vref: 58,
+                                rx_dfe: 1,
+                                tx_dfe: 1
+                              }
+                            }
+                          ]
+                        },
+                        {
+                          header: {
+                            group_id: 5892,
+                            entry_id: 142,
+                            instance_id: 0,
+                            context_type: "Struct",
+                            context_format: "Raw",
+                            unit_size: 0,
+                            priority_mask: {
+                              hard_force: false,
+                              high: false,
+                              medium: false,
+                              event_logging: false,
+                              low: false,
+                              normal: true,
+                            },
+                            key_size: 0,
+                            key_pos: 0,
+                            board_instance_mask: 65535
+                          },
+                          MaxFreqElement: [
+                            {
+                              dimm_slots_per_channel: {
+                                Specific: {
+                                  one_dimm: true,
+                                  two_dimms: false,
+                                  three_dimms: false,
+                                  four_dimms: false,
+                                }
+                              },
+                              conditions: [
+                                1,
+                                1,
+                                0,
+                                0
+                              ],
+                              speeds: [
+                                3000,
+                                4401,
+                                4401
+                              ]
+                            },
+                            {
+                              dimm_slots_per_channel: {
+                                Specific: {
+                                  one_dimm: true,
+                                  two_dimms: false,
+                                  three_dimms: false,
+                                  four_dimms: false,
+                                }
+                              },
+                              conditions: [
+                                1,
+                                0,
+                                1,
+                                0
+                              ],
+                              speeds: [
+                                3000,
+                                4401,
+                                4401
+                              ]
+                            },
+                            {
+                              dimm_slots_per_channel: {
+                                Specific: {
+                                  one_dimm: false,
+                                  two_dimms: true,
+                                  three_dimms: false,
+                                  four_dimms: false,
+                                }
+                              },
+                              conditions: [
+                                1,
+                                1,
+                                0,
+                                0
+                              ],
+                              speeds: [
+                                2600,
+                                4401,
+                                4401
+                              ]
+                            },
+                            {
+                              dimm_slots_per_channel: {
+                                Specific: {
+                                  one_dimm: false,
+                                  two_dimms: true,
+                                  three_dimms: false,
+                                  four_dimms: false,
+                                }
+                              },
+                              conditions: [
+                                1,
+                                0,
+                                1,
+                                0
+                              ],
+                              speeds: [
+                                2600,
+                                4401,
+                                4401
+                              ]
+                            },
+                            {
+                              dimm_slots_per_channel: {
+                                Specific: {
+                                  one_dimm: false,
+                                  two_dimms: true,
+                                  three_dimms: false,
+                                  four_dimms: false,
+                                }
+                              },
+                              conditions: [
+                                2,
+                                2,
+                                0,
+                                0
+                              ],
+                              speeds: [
+                                2200,
+                                4401,
+                                4401
+                              ]
+                            },
+                            {
+                              dimm_slots_per_channel: {
+                                Specific: {
+                                  one_dimm: false,
+                                  two_dimms: true,
+                                  three_dimms: false,
+                                  four_dimms: false,
+                                }
+                              },
+                              conditions: [
+                                2,
+                                0,
+                                2,
+                                0
+                              ],
+                              speeds: [
+                                2000,
+                                4401,
+                                4401
+                              ]
+                            }
+                          ]
+                        },
+                        {
+                          header: {
+                            group_id: 5892,
+                            entry_id: 148,
+                            instance_id: 0,
+                            context_type: "Struct",
+                            context_format: "Raw",
+                            unit_size: 0,
+                            priority_mask: {
+                              hard_force: false,
+                              high: false,
+                              medium: false,
+                              event_logging: false,
+                              low: false,
+                              normal: true,
+                            },
+                            key_size: 0,
+                            key_pos: 0,
+                            board_instance_mask: 65535
+                          },
+                          MaxFreqElement: [
+                            {
+                              dimm_slots_per_channel: {
+                                Specific: {
+                                  one_dimm: true,
+                                  two_dimms: false,
+                                  three_dimms: false,
+                                  four_dimms: false,
+                                }
+                              },
+                              conditions: [
+                                1,
+                                0,
+                                1,
+                                0
+                              ],
+                              speeds: [
+                                3000,
+                                4401,
+                                4401
+                              ]
+                            },
+                            {
+                              dimm_slots_per_channel: {
+                                Specific: {
+                                  one_dimm: false,
+                                  two_dimms: true,
+                                  three_dimms: false,
+                                  four_dimms: false,
+                                }
+                              },
+                              conditions: [
+                                1,
+                                0,
+                                1,
+                                0
+                              ],
+                              speeds: [
+                                2600,
+                                4401,
+                                4401
+                              ]
+                            },
+                            {
+                              dimm_slots_per_channel: {
+                                Specific: {
+                                  one_dimm: false,
+                                  two_dimms: true,
+                                  three_dimms: false,
+                                  four_dimms: false,
+                                }
+                              },
+                              conditions: [
+                                2,
+                                0,
+                                2,
+                                0
+                              ],
+                              speeds: [
+                                2000,
+                                4401,
+                                4401
+                              ]
+                            }
+                          ]
+                        },
+                        {
+                          header: {
+                            group_id: 5892,
+                            entry_id: 161,
+                            instance_id: 0,
+                            context_type: "Struct",
+                            context_format: "Raw",
+                            unit_size: 0,
+                            priority_mask: {
+                              hard_force: false,
+                              high: false,
+                              medium: false,
+                              event_logging: false,
+                              low: false,
+                              normal: true,
+                            },
+                            key_size: 0,
+                            key_pos: 0,
+                            board_instance_mask: 65535
+                          },
+                          PmuBistVendorAlgorithmElement: [
+                            {
+                              dram_manufacturer_id: 52864,
+                              algorithm_bit_mask: 388
+                            },
+                            {
+                              dram_manufacturer_id: 44416,
+                              algorithm_bit_mask: 40
+                            },
+                            {
+                              dram_manufacturer_id: 11392,
+                              algorithm_bit_mask: 64
+                            }
+                          ]
+                        },
+                        {
+                          header: {
+                            group_id: 5892,
+                            entry_id: 162,
+                            instance_id: 11392,
+                            context_type: "Struct",
+                            context_format: "Raw",
+                            unit_size: 0,
+                            priority_mask: {
+                              hard_force: false,
+                              high: false,
+                              medium: false,
+                              event_logging: false,
+                              low: false,
+                              normal: true,
+                            },
+                            key_size: 0,
+                            key_pos: 0,
+                            board_instance_mask: 65535
+                          },
+                          Ddr5RawCardConfigElement: [
+                            {
+                              header: {
+                                total_size: 32,
+                                mem_clk: "Ddr7200",
+                                dimm_type: 2,
+                                dev_width: 2,
+                                rcd_manufacturer_id: 65535,
+                                rcd_generation: 0,
+                                raw_card_dev: 65535,
+                                dram_die_stepping_revision: 65535,
+                                dram_density: 255,
+                              },
+                              payload: {
+                                total_size: 80,
+                                qck_dev0: "Off",
+                                qck_dev1: "Off",
+                                qck_dev2: "Off",
+                                qck_dev3: "Off",
+                                qck_dev4: "40 Ω",
+                                qck_dev5: "Off",
+                                qck_dev6: "Off",
+                                qck_dev7: "Off",
+                                qck_dev8: "Off",
+                                qck_dev9: "40 Ω",
+                                qck_drive_strength: 1,
+                                qck_slew: "Default",
+                                qcs_dev0: "Off",
+                                qcs_dev1: "Off",
+                                qcs_dev2: "Off",
+                                qcs_dev3: "Off",
+                                qcs_dev4: "40 Ω",
+                                qcs_dev5: "Off",
+                                qcs_dev6: "Off",
+                                qcs_dev7: "Off",
+                                qcs_dev8: "Off",
+                                qcs_dev9: "40 Ω",
+                                qcs_drive_strength: 0,
+                                qcs_slew: "Default",
+                                qcs_vref: "66.0%",
+                                qca_dev0: "240 Ω",
+                                qca_dev1: "240 Ω",
+                                qca_dev2: "240 Ω",
+                                qca_dev3: "240 Ω",
+                                qca_dev4: "60 Ω",
+                                qca_dev5: "240 Ω",
+                                qca_dev6: "240 Ω",
+                                qca_dev7: "240 Ω",
+                                qca_dev8: "240 Ω",
+                                qca_dev9: "60 Ω",
+                                qca_drive_strength: 0,
+                                qca_slew: "Default",
+                                qca_vref: "69.5%"
+                              }
+                            },
+                            {
+                              header: {
+                                total_size: 32,
+                                mem_clk: "Ddr7200",
+                                dimm_type: 2,
+                                dev_width: 1,
+                                rcd_manufacturer_id: 65535,
+                                rcd_generation: 0,
+                                raw_card_dev: 65535,
+                                dram_die_stepping_revision: 65535,
+                                dram_density: 255,
+                              },
+                              payload: {
+                                total_size: 80,
+                                qck_dev0: "Off",
+                                qck_dev1: "Off",
+                                qck_dev2: "Off",
+                                qck_dev3: "Off",
+                                qck_dev4: "40 Ω",
+                                qck_dev5: "Off",
+                                qck_dev6: "Off",
+                                qck_dev7: "Off",
+                                qck_dev8: "Off",
+                                qck_dev9: "40 Ω",
+                                qck_drive_strength: 1,
+                                qck_slew: "Default",
+                                qcs_dev0: "Off",
+                                qcs_dev1: "Off",
+                                qcs_dev2: "Off",
+                                qcs_dev3: "Off",
+                                qcs_dev4: "40 Ω",
+                                qcs_dev5: "Off",
+                                qcs_dev6: "Off",
+                                qcs_dev7: "Off",
+                                qcs_dev8: "Off",
+                                qcs_dev9: "40 Ω",
+                                qcs_drive_strength: 0,
+                                qcs_slew: "Default",
+                                qcs_vref: "66.0%",
+                                qca_dev0: "Off",
+                                qca_dev1: "Off",
+                                qca_dev2: "Off",
+                                qca_dev3: "Off",
+                                qca_dev4: "60 Ω",
+                                qca_dev5: "Off",
+                                qca_dev6: "Off",
+                                qca_dev7: "Off",
+                                qca_dev8: "Off",
+                                qca_dev9: "60 Ω",
+                                qca_drive_strength: 0,
+                                qca_slew: "Default",
+                                qca_vref: "69.5%"
+                              }
+                            },
+                            {
+                              header: {
+                                total_size: 32,
+                                mem_clk: "Ddr7200",
+                                dimm_type: 4,
+                                dev_width: 2,
+                                rcd_manufacturer_id: 65535,
+                                rcd_generation: 0,
+                                raw_card_dev: 65535,
+                                dram_die_stepping_revision: 65535,
+                                dram_density: 255,
+                              },
+                              payload: {
+                                total_size: 80,
+                                qck_dev0: "Off",
+                                qck_dev1: "Off",
+                                qck_dev2: "Off",
+                                qck_dev3: "Off",
+                                qck_dev4: "40 Ω",
+                                qck_dev5: "Off",
+                                qck_dev6: "Off",
+                                qck_dev7: "Off",
+                                qck_dev8: "Off",
+                                qck_dev9: "40 Ω",
+                                qck_drive_strength: 1,
+                                qck_slew: "Default",
+                                qcs_dev0: "Off",
+                                qcs_dev1: "Off",
+                                qcs_dev2: "Off",
+                                qcs_dev3: "Off",
+                                qcs_dev4: "40 Ω",
+                                qcs_dev5: "Off",
+                                qcs_dev6: "Off",
+                                qcs_dev7: "Off",
+                                qcs_dev8: "Off",
+                                qcs_dev9: "40 Ω",
+                                qcs_drive_strength: 0,
+                                qcs_slew: "Default",
+                                qcs_vref: "66.0%",
+                                qca_dev0: "Off",
+                                qca_dev1: "Off",
+                                qca_dev2: "Off",
+                                qca_dev3: "Off",
+                                qca_dev4: "60 Ω",
+                                qca_dev5: "Off",
+                                qca_dev6: "Off",
+                                qca_dev7: "Off",
+                                qca_dev8: "Off",
+                                qca_dev9: "60 Ω",
+                                qca_drive_strength: 0,
+                                qca_slew: "Default",
+                                qca_vref: "69.5%"
+                              }
+                            },
+                            {
+                              header: {
+                                total_size: 32,
+                                mem_clk: "Ddr7200",
+                                dimm_type: 255,
+                                dev_width: 255,
+                                rcd_manufacturer_id: 65535,
+                                rcd_generation: 0,
+                                raw_card_dev: 65535,
+                                dram_die_stepping_revision: 65535,
+                                dram_density: 255,
+                              },
+                              payload: {
+                                total_size: 80,
+                                qck_dev0: "Off",
+                                qck_dev1: "Off",
+                                qck_dev2: "Off",
+                                qck_dev3: "Off",
+                                qck_dev4: "40 Ω",
+                                qck_dev5: "Off",
+                                qck_dev6: "Off",
+                                qck_dev7: "Off",
+                                qck_dev8: "Off",
+                                qck_dev9: "40 Ω",
+                                qck_drive_strength: 1,
+                                qck_slew: "Default",
+                                qcs_dev0: "Off",
+                                qcs_dev1: "Off",
+                                qcs_dev2: "Off",
+                                qcs_dev3: "Off",
+                                qcs_dev4: "40 Ω",
+                                qcs_dev5: "Off",
+                                qcs_dev6: "Off",
+                                qcs_dev7: "Off",
+                                qcs_dev8: "Off",
+                                qcs_dev9: "40 Ω",
+                                qcs_drive_strength: 0,
+                                qcs_slew: "Default",
+                                qcs_vref: "66.0%",
+                                qca_dev0: "Off",
+                                qca_dev1: "Off",
+                                qca_dev2: "Off",
+                                qca_dev3: "Off",
+                                qca_dev4: "60 Ω",
+                                qca_dev5: "Off",
+                                qca_dev6: "Off",
+                                qca_dev7: "Off",
+                                qca_dev8: "Off",
+                                qca_dev9: "60 Ω",
+                                qca_drive_strength: 0,
+                                qca_slew: "Default",
+                                qca_vref: "69.5%"
+                              }
+                            },
+                            {
+                              header: {
+                                total_size: 32,
+                                mem_clk: "Ddr7200",
+                                dimm_type: 2,
+                                dev_width: 2,
+                                rcd_manufacturer_id: 65535,
+                                rcd_generation: 1,
+                                raw_card_dev: 65535,
+                                dram_die_stepping_revision: 65535,
+                                dram_density: 255,
+                              },
+                              payload: {
+                                total_size: 80,
+                                qck_dev0: "Off",
+                                qck_dev1: "Off",
+                                qck_dev2: "Off",
+                                qck_dev3: "Off",
+                                qck_dev4: "40 Ω",
+                                qck_dev5: "Off",
+                                qck_dev6: "Off",
+                                qck_dev7: "Off",
+                                qck_dev8: "Off",
+                                qck_dev9: "40 Ω",
+                                qck_drive_strength: 1,
+                                qck_slew: "Default",
+                                qcs_dev0: "Off",
+                                qcs_dev1: "Off",
+                                qcs_dev2: "Off",
+                                qcs_dev3: "Off",
+                                qcs_dev4: "40 Ω",
+                                qcs_dev5: "Off",
+                                qcs_dev6: "Off",
+                                qcs_dev7: "Off",
+                                qcs_dev8: "Off",
+                                qcs_dev9: "40 Ω",
+                                qcs_drive_strength: 0,
+                                qcs_slew: "Default",
+                                qcs_vref: "66.0%",
+                                qca_dev0: "240 Ω",
+                                qca_dev1: "240 Ω",
+                                qca_dev2: "240 Ω",
+                                qca_dev3: "240 Ω",
+                                qca_dev4: "60 Ω",
+                                qca_dev5: "240 Ω",
+                                qca_dev6: "240 Ω",
+                                qca_dev7: "240 Ω",
+                                qca_dev8: "240 Ω",
+                                qca_dev9: "60 Ω",
+                                qca_drive_strength: 0,
+                                qca_slew: "Default",
+                                qca_vref: "69.5%"
+                              }
+                            },
+                            {
+                              header: {
+                                total_size: 32,
+                                mem_clk: "Ddr7200",
+                                dimm_type: 2,
+                                dev_width: 1,
+                                rcd_manufacturer_id: 65535,
+                                rcd_generation: 1,
+                                raw_card_dev: 65535,
+                                dram_die_stepping_revision: 65535,
+                                dram_density: 255,
+                              },
+                              payload: {
+                                total_size: 80,
+                                qck_dev0: "Off",
+                                qck_dev1: "Off",
+                                qck_dev2: "Off",
+                                qck_dev3: "Off",
+                                qck_dev4: "40 Ω",
+                                qck_dev5: "Off",
+                                qck_dev6: "Off",
+                                qck_dev7: "Off",
+                                qck_dev8: "Off",
+                                qck_dev9: "40 Ω",
+                                qck_drive_strength: 1,
+                                qck_slew: "Default",
+                                qcs_dev0: "Off",
+                                qcs_dev1: "Off",
+                                qcs_dev2: "Off",
+                                qcs_dev3: "Off",
+                                qcs_dev4: "40 Ω",
+                                qcs_dev5: "Off",
+                                qcs_dev6: "Off",
+                                qcs_dev7: "Off",
+                                qcs_dev8: "Off",
+                                qcs_dev9: "40 Ω",
+                                qcs_drive_strength: 0,
+                                qcs_slew: "Default",
+                                qcs_vref: "66.0%",
+                                qca_dev0: "Off",
+                                qca_dev1: "Off",
+                                qca_dev2: "Off",
+                                qca_dev3: "Off",
+                                qca_dev4: "60 Ω",
+                                qca_dev5: "Off",
+                                qca_dev6: "Off",
+                                qca_dev7: "Off",
+                                qca_dev8: "Off",
+                                qca_dev9: "60 Ω",
+                                qca_drive_strength: 0,
+                                qca_slew: "Default",
+                                qca_vref: "69.5%"
+                              }
+                            },
+                            {
+                              header: {
+                                total_size: 32,
+                                mem_clk: "Ddr7200",
+                                dimm_type: 4,
+                                dev_width: 2,
+                                rcd_manufacturer_id: 65535,
+                                rcd_generation: 1,
+                                raw_card_dev: 65535,
+                                dram_die_stepping_revision: 65535,
+                                dram_density: 255,
+                              },
+                              payload: {
+                                total_size: 80,
+                                qck_dev0: "Off",
+                                qck_dev1: "Off",
+                                qck_dev2: "Off",
+                                qck_dev3: "Off",
+                                qck_dev4: "40 Ω",
+                                qck_dev5: "Off",
+                                qck_dev6: "Off",
+                                qck_dev7: "Off",
+                                qck_dev8: "Off",
+                                qck_dev9: "40 Ω",
+                                qck_drive_strength: 1,
+                                qck_slew: "Default",
+                                qcs_dev0: "Off",
+                                qcs_dev1: "Off",
+                                qcs_dev2: "Off",
+                                qcs_dev3: "Off",
+                                qcs_dev4: "40 Ω",
+                                qcs_dev5: "Off",
+                                qcs_dev6: "Off",
+                                qcs_dev7: "Off",
+                                qcs_dev8: "Off",
+                                qcs_dev9: "40 Ω",
+                                qcs_drive_strength: 0,
+                                qcs_slew: "Default",
+                                qcs_vref: "66.0%",
+                                qca_dev0: "Off",
+                                qca_dev1: "Off",
+                                qca_dev2: "Off",
+                                qca_dev3: "Off",
+                                qca_dev4: "60 Ω",
+                                qca_dev5: "Off",
+                                qca_dev6: "Off",
+                                qca_dev7: "Off",
+                                qca_dev8: "Off",
+                                qca_dev9: "60 Ω",
+                                qca_drive_strength: 0,
+                                qca_slew: "Default",
+                                qca_vref: "69.5%"
+                              }
+                            },
+                            {
+                              header: {
+                                total_size: 32,
+                                mem_clk: "Ddr7200",
+                                dimm_type: 255,
+                                dev_width: 255,
+                                rcd_manufacturer_id: 65535,
+                                rcd_generation: 1,
+                                raw_card_dev: 65535,
+                                dram_die_stepping_revision: 65535,
+                                dram_density: 255,
+                              },
+                              payload: {
+                                total_size: 80,
+                                qck_dev0: "Off",
+                                qck_dev1: "Off",
+                                qck_dev2: "Off",
+                                qck_dev3: "Off",
+                                qck_dev4: "40 Ω",
+                                qck_dev5: "Off",
+                                qck_dev6: "Off",
+                                qck_dev7: "Off",
+                                qck_dev8: "Off",
+                                qck_dev9: "40 Ω",
+                                qck_drive_strength: 1,
+                                qck_slew: "Default",
+                                qcs_dev0: "Off",
+                                qcs_dev1: "Off",
+                                qcs_dev2: "Off",
+                                qcs_dev3: "Off",
+                                qcs_dev4: "40 Ω",
+                                qcs_dev5: "Off",
+                                qcs_dev6: "Off",
+                                qcs_dev7: "Off",
+                                qcs_dev8: "Off",
+                                qcs_dev9: "40 Ω",
+                                qcs_drive_strength: 0,
+                                qcs_slew: "Default",
+                                qcs_vref: "66.0%",
+                                qca_dev0: "Off",
+                                qca_dev1: "Off",
+                                qca_dev2: "Off",
+                                qca_dev3: "Off",
+                                qca_dev4: "60 Ω",
+                                qca_dev5: "Off",
+                                qca_dev6: "Off",
+                                qca_dev7: "Off",
+                                qca_dev8: "Off",
+                                qca_dev9: "60 Ω",
+                                qca_drive_strength: 0,
+                                qca_slew: "Default",
+                                qca_vref: "69.5%"
+                              }
+                            },
+                            {
+                              header: {
+                                total_size: 32,
+                                mem_clk: "Ddr5600",
+                                dimm_type: 4,
+                                dev_width: 1,
+                                rcd_manufacturer_id: 65535,
+                                rcd_generation: 255,
+                                raw_card_dev: 65535,
+                                dram_die_stepping_revision: 65535,
+                                dram_density: 255,
+                              },
+                              payload: {
+                                total_size: 80,
+                                qck_dev0: "Off",
+                                qck_dev1: "Off",
+                                qck_dev2: "Off",
+                                qck_dev3: "Off",
+                                qck_dev4: "40 Ω",
+                                qck_dev5: "Off",
+                                qck_dev6: "Off",
+                                qck_dev7: "Off",
+                                qck_dev8: "Off",
+                                qck_dev9: "40 Ω",
+                                qck_drive_strength: 2,
+                                qck_slew: "Default",
+                                qcs_dev0: "Off",
+                                qcs_dev1: "Off",
+                                qcs_dev2: "Off",
+                                qcs_dev3: "Off",
+                                qcs_dev4: "40 Ω",
+                                qcs_dev5: "Off",
+                                qcs_dev6: "Off",
+                                qcs_dev7: "Off",
+                                qcs_dev8: "Off",
+                                qcs_dev9: "40 Ω",
+                                qcs_drive_strength: 1,
+                                qcs_slew: "Default",
+                                qcs_vref: "66.0%",
+                                qca_dev0: "Off",
+                                qca_dev1: "Off",
+                                qca_dev2: "Off",
+                                qca_dev3: "Off",
+                                qca_dev4: "60 Ω",
+                                qca_dev5: "Off",
+                                qca_dev6: "Off",
+                                qca_dev7: "Off",
+                                qca_dev8: "Off",
+                                qca_dev9: "60 Ω",
+                                qca_drive_strength: 1,
+                                qca_slew: "Default",
+                                qca_vref: "69.5%"
+                              }
+                            },
+                            {
+                              header: {
+                                total_size: 32,
+                                mem_clk: "Ddr5600",
+                                dimm_type: 2,
+                                dev_width: 1,
+                                rcd_manufacturer_id: 65535,
+                                rcd_generation: 255,
+                                raw_card_dev: 65535,
+                                dram_die_stepping_revision: 65535,
+                                dram_density: 255,
+                              },
+                              payload: {
+                                total_size: 80,
+                                qck_dev0: "Off",
+                                qck_dev1: "Off",
+                                qck_dev2: "Off",
+                                qck_dev3: "Off",
+                                qck_dev4: "40 Ω",
+                                qck_dev5: "Off",
+                                qck_dev6: "Off",
+                                qck_dev7: "Off",
+                                qck_dev8: "Off",
+                                qck_dev9: "40 Ω",
+                                qck_drive_strength: 2,
+                                qck_slew: "Default",
+                                qcs_dev0: "Off",
+                                qcs_dev1: "Off",
+                                qcs_dev2: "Off",
+                                qcs_dev3: "Off",
+                                qcs_dev4: "40 Ω",
+                                qcs_dev5: "Off",
+                                qcs_dev6: "Off",
+                                qcs_dev7: "Off",
+                                qcs_dev8: "Off",
+                                qcs_dev9: "40 Ω",
+                                qcs_drive_strength: 1,
+                                qcs_slew: "Default",
+                                qcs_vref: "66.0%",
+                                qca_dev0: "Off",
+                                qca_dev1: "Off",
+                                qca_dev2: "Off",
+                                qca_dev3: "Off",
+                                qca_dev4: "60 Ω",
+                                qca_dev5: "Off",
+                                qca_dev6: "Off",
+                                qca_dev7: "Off",
+                                qca_dev8: "Off",
+                                qca_dev9: "60 Ω",
+                                qca_drive_strength: 1,
+                                qca_slew: "Default",
+                                qca_vref: "69.5%"
+                              }
+                            },
+                            {
+                              header: {
+                                total_size: 32,
+                                mem_clk: "Ddr5600",
+                                dimm_type: 4,
+                                dev_width: 2,
+                                rcd_manufacturer_id: 65535,
+                                rcd_generation: 255,
+                                raw_card_dev: 65535,
+                                dram_die_stepping_revision: 65535,
+                                dram_density: 255,
+                              },
+                              payload: {
+                                total_size: 80,
+                                qck_dev0: "Off",
+                                qck_dev1: "Off",
+                                qck_dev2: "Off",
+                                qck_dev3: "Off",
+                                qck_dev4: "40 Ω",
+                                qck_dev5: "Off",
+                                qck_dev6: "Off",
+                                qck_dev7: "Off",
+                                qck_dev8: "Off",
+                                qck_dev9: "40 Ω",
+                                qck_drive_strength: 2,
+                                qck_slew: "Default",
+                                qcs_dev0: "Off",
+                                qcs_dev1: "Off",
+                                qcs_dev2: "Off",
+                                qcs_dev3: "Off",
+                                qcs_dev4: "40 Ω",
+                                qcs_dev5: "Off",
+                                qcs_dev6: "Off",
+                                qcs_dev7: "Off",
+                                qcs_dev8: "Off",
+                                qcs_dev9: "40 Ω",
+                                qcs_drive_strength: 1,
+                                qcs_slew: "Default",
+                                qcs_vref: "66.0%",
+                                qca_dev0: "Off",
+                                qca_dev1: "Off",
+                                qca_dev2: "Off",
+                                qca_dev3: "Off",
+                                qca_dev4: "60 Ω",
+                                qca_dev5: "Off",
+                                qca_dev6: "Off",
+                                qca_dev7: "Off",
+                                qca_dev8: "Off",
+                                qca_dev9: "60 Ω",
+                                qca_drive_strength: 1,
+                                qca_slew: "Default",
+                                qca_vref: "69.5%"
+                              }
+                            },
+                            {
+                              header: {
+                                total_size: 32,
+                                mem_clk: "Ddr7200",
+                                dimm_type: 2,
+                                dev_width: 2,
+                                rcd_manufacturer_id: 65535,
+                                rcd_generation: 255,
+                                raw_card_dev: 65535,
+                                dram_die_stepping_revision: 65535,
+                                dram_density: 255,
+                              },
+                              payload: {
+                                total_size: 80,
+                                qck_dev0: "Off",
+                                qck_dev1: "Off",
+                                qck_dev2: "Off",
+                                qck_dev3: "Off",
+                                qck_dev4: "40 Ω",
+                                qck_dev5: "Off",
+                                qck_dev6: "Off",
+                                qck_dev7: "Off",
+                                qck_dev8: "Off",
+                                qck_dev9: "40 Ω",
+                                qck_drive_strength: 2,
+                                qck_slew: "Default",
+                                qcs_dev0: "Off",
+                                qcs_dev1: "Off",
+                                qcs_dev2: "Off",
+                                qcs_dev3: "Off",
+                                qcs_dev4: "40 Ω",
+                                qcs_dev5: "Off",
+                                qcs_dev6: "Off",
+                                qcs_dev7: "Off",
+                                qcs_dev8: "Off",
+                                qcs_dev9: "40 Ω",
+                                qcs_drive_strength: 1,
+                                qcs_slew: "Default",
+                                qcs_vref: "66.0%",
+                                qca_dev0: "240 Ω",
+                                qca_dev1: "240 Ω",
+                                qca_dev2: "240 Ω",
+                                qca_dev3: "240 Ω",
+                                qca_dev4: "60 Ω",
+                                qca_dev5: "240 Ω",
+                                qca_dev6: "240 Ω",
+                                qca_dev7: "240 Ω",
+                                qca_dev8: "240 Ω",
+                                qca_dev9: "60 Ω",
+                                qca_drive_strength: 1,
+                                qca_slew: "Default",
+                                qca_vref: "69.5%"
+                              }
+                            },
+                            {
+                              header: {
+                                total_size: 32,
+                                mem_clk: "Ddr7200",
+                                dimm_type: 2,
+                                dev_width: 1,
+                                rcd_manufacturer_id: 65535,
+                                rcd_generation: 255,
+                                raw_card_dev: 65535,
+                                dram_die_stepping_revision: 65535,
+                                dram_density: 255,
+                              },
+                              payload: {
+                                total_size: 80,
+                                qck_dev0: "Off",
+                                qck_dev1: "Off",
+                                qck_dev2: "Off",
+                                qck_dev3: "Off",
+                                qck_dev4: "40 Ω",
+                                qck_dev5: "Off",
+                                qck_dev6: "Off",
+                                qck_dev7: "Off",
+                                qck_dev8: "Off",
+                                qck_dev9: "40 Ω",
+                                qck_drive_strength: 2,
+                                qck_slew: "Moderate",
+                                qcs_dev0: "Off",
+                                qcs_dev1: "Off",
+                                qcs_dev2: "Off",
+                                qcs_dev3: "Off",
+                                qcs_dev4: "40 Ω",
+                                qcs_dev5: "Off",
+                                qcs_dev6: "Off",
+                                qcs_dev7: "Off",
+                                qcs_dev8: "Off",
+                                qcs_dev9: "40 Ω",
+                                qcs_drive_strength: 1,
+                                qcs_slew: "Slow",
+                                qcs_vref: "71.0%",
+                                qca_dev0: "480 Ω",
+                                qca_dev1: "480 Ω",
+                                qca_dev2: "480 Ω",
+                                qca_dev3: "480 Ω",
+                                qca_dev4: "40 Ω",
+                                qca_dev5: "480 Ω",
+                                qca_dev6: "480 Ω",
+                                qca_dev7: "480 Ω",
+                                qca_dev8: "480 Ω",
+                                qca_dev9: "40 Ω",
+                                qca_drive_strength: 2,
+                                qca_slew: "Slow",
+                                qca_vref: "75.5%"
+                              }
+                            },
+                            {
+                              header: {
+                                total_size: 32,
+                                mem_clk: "Ddr7200",
+                                dimm_type: 4,
+                                dev_width: 2,
+                                rcd_manufacturer_id: 65535,
+                                rcd_generation: 255,
+                                raw_card_dev: 65535,
+                                dram_die_stepping_revision: 65535,
+                                dram_density: 255,
+                              },
+                              payload: {
+                                total_size: 80,
+                                qck_dev0: "Off",
+                                qck_dev1: "Off",
+                                qck_dev2: "Off",
+                                qck_dev3: "Off",
+                                qck_dev4: "40 Ω",
+                                qck_dev5: "Off",
+                                qck_dev6: "Off",
+                                qck_dev7: "Off",
+                                qck_dev8: "Off",
+                                qck_dev9: "40 Ω",
+                                qck_drive_strength: 2,
+                                qck_slew: "Moderate",
+                                qcs_dev0: "Off",
+                                qcs_dev1: "Off",
+                                qcs_dev2: "Off",
+                                qcs_dev3: "Off",
+                                qcs_dev4: "40 Ω",
+                                qcs_dev5: "Off",
+                                qcs_dev6: "Off",
+                                qcs_dev7: "Off",
+                                qcs_dev8: "Off",
+                                qcs_dev9: "40 Ω",
+                                qcs_drive_strength: 1,
+                                qcs_slew: "Slow",
+                                qcs_vref: "71.0%",
+                                qca_dev0: "480 Ω",
+                                qca_dev1: "480 Ω",
+                                qca_dev2: "480 Ω",
+                                qca_dev3: "480 Ω",
+                                qca_dev4: "40 Ω",
+                                qca_dev5: "480 Ω",
+                                qca_dev6: "480 Ω",
+                                qca_dev7: "480 Ω",
+                                qca_dev8: "480 Ω",
+                                qca_dev9: "40 Ω",
+                                qca_drive_strength: 2,
+                                qca_slew: "Slow",
+                                qca_vref: "75.5%"
+                              }
+                            },
+                            {
+                              header: {
+                                total_size: 32,
+                                mem_clk: "Ddr7200",
+                                dimm_type: 255,
+                                dev_width: 255,
+                                rcd_manufacturer_id: 65535,
+                                rcd_generation: 255,
+                                raw_card_dev: 65535,
+                                dram_die_stepping_revision: 65535,
+                                dram_density: 255,
+                              },
+                              payload: {
+                                total_size: 80,
+                                qck_dev0: "Off",
+                                qck_dev1: "Off",
+                                qck_dev2: "Off",
+                                qck_dev3: "Off",
+                                qck_dev4: "40 Ω",
+                                qck_dev5: "Off",
+                                qck_dev6: "Off",
+                                qck_dev7: "Off",
+                                qck_dev8: "Off",
+                                qck_dev9: "40 Ω",
+                                qck_drive_strength: 2,
+                                qck_slew: "Moderate",
+                                qcs_dev0: "Off",
+                                qcs_dev1: "Off",
+                                qcs_dev2: "Off",
+                                qcs_dev3: "Off",
+                                qcs_dev4: "40 Ω",
+                                qcs_dev5: "Off",
+                                qcs_dev6: "Off",
+                                qcs_dev7: "Off",
+                                qcs_dev8: "Off",
+                                qcs_dev9: "40 Ω",
+                                qcs_drive_strength: 1,
+                                qcs_slew: "Slow",
+                                qcs_vref: "71.0%",
+                                qca_dev0: "480 Ω",
+                                qca_dev1: "480 Ω",
+                                qca_dev2: "480 Ω",
+                                qca_dev3: "480 Ω",
+                                qca_dev4: "40 Ω",
+                                qca_dev5: "480 Ω",
+                                qca_dev6: "480 Ω",
+                                qca_dev7: "480 Ω",
+                                qca_dev8: "480 Ω",
+                                qca_dev9: "40 Ω",
+                                qca_drive_strength: 2,
+                                qca_slew: "Slow",
+                                qca_vref: "75.5%"
+                              }
+                            }
+                          ]
+                        },
+                        {
+                          header: {
+                            group_id: 5892,
+                            entry_id: 162,
+                            instance_id: 44416,
+                            context_type: "Struct",
+                            context_format: "Raw",
+                            unit_size: 0,
+                            priority_mask: {
+                              normal: true,
+                            },
+                            key_size: 0,
+                            key_pos: 0,
+                            board_instance_mask: 65535
+                          },
+                          Ddr5RawCardConfigElement: [
+                            {
+                              header: {
+                                total_size: 32,
+                                mem_clk: "Ddr7200",
+                                dimm_type: 2,
+                                dev_width: 2,
+                                rcd_manufacturer_id: 65535,
+                                rcd_generation: 0,
+                                raw_card_dev: 65535,
+                                dram_die_stepping_revision: 65535,
+                                dram_density: 255,
+                              },
+                              payload: {
+                                total_size: 80,
+                                qck_dev0: "Off",
+                                qck_dev1: "Off",
+                                qck_dev2: "Off",
+                                qck_dev3: "Off",
+                                qck_dev4: "40 Ω",
+                                qck_dev5: "Off",
+                                qck_dev6: "Off",
+                                qck_dev7: "Off",
+                                qck_dev8: "Off",
+                                qck_dev9: "40 Ω",
+                                qck_drive_strength: 1,
+                                qck_slew: "Default",
+                                qcs_dev0: "Off",
+                                qcs_dev1: "Off",
+                                qcs_dev2: "Off",
+                                qcs_dev3: "Off",
+                                qcs_dev4: "40 Ω",
+                                qcs_dev5: "Off",
+                                qcs_dev6: "Off",
+                                qcs_dev7: "Off",
+                                qcs_dev8: "Off",
+                                qcs_dev9: "40 Ω",
+                                qcs_drive_strength: 0,
+                                qcs_slew: "Default",
+                                qcs_vref: "66.0%",
+                                qca_dev0: "240 Ω",
+                                qca_dev1: "240 Ω",
+                                qca_dev2: "240 Ω",
+                                qca_dev3: "240 Ω",
+                                qca_dev4: "60 Ω",
+                                qca_dev5: "240 Ω",
+                                qca_dev6: "240 Ω",
+                                qca_dev7: "240 Ω",
+                                qca_dev8: "240 Ω",
+                                qca_dev9: "60 Ω",
+                                qca_drive_strength: 0,
+                                qca_slew: "Default",
+                                qca_vref: "69.5%"
+                              }
+                            },
+                            {
+                              header: {
+                                total_size: 32,
+                                mem_clk: "Ddr7200",
+                                dimm_type: 2,
+                                dev_width: 1,
+                                rcd_manufacturer_id: 65535,
+                                rcd_generation: 0,
+                                raw_card_dev: 65535,
+                                dram_die_stepping_revision: 65535,
+                                dram_density: 255,
+                              },
+                              payload: {
+                                total_size: 80,
+                                qck_dev0: "Off",
+                                qck_dev1: "Off",
+                                qck_dev2: "Off",
+                                qck_dev3: "Off",
+                                qck_dev4: "40 Ω",
+                                qck_dev5: "Off",
+                                qck_dev6: "Off",
+                                qck_dev7: "Off",
+                                qck_dev8: "Off",
+                                qck_dev9: "40 Ω",
+                                qck_drive_strength: 1,
+                                qck_slew: "Default",
+                                qcs_dev0: "Off",
+                                qcs_dev1: "Off",
+                                qcs_dev2: "Off",
+                                qcs_dev3: "Off",
+                                qcs_dev4: "40 Ω",
+                                qcs_dev5: "Off",
+                                qcs_dev6: "Off",
+                                qcs_dev7: "Off",
+                                qcs_dev8: "Off",
+                                qcs_dev9: "40 Ω",
+                                qcs_drive_strength: 0,
+                                qcs_slew: "Default",
+                                qcs_vref: "66.0%",
+                                qca_dev0: "Off",
+                                qca_dev1: "Off",
+                                qca_dev2: "Off",
+                                qca_dev3: "Off",
+                                qca_dev4: "60 Ω",
+                                qca_dev5: "Off",
+                                qca_dev6: "Off",
+                                qca_dev7: "Off",
+                                qca_dev8: "Off",
+                                qca_dev9: "60 Ω",
+                                qca_drive_strength: 0,
+                                qca_slew: "Default",
+                                qca_vref: "69.5%"
+                              }
+                            },
+                            {
+                              header: {
+                                total_size: 32,
+                                mem_clk: "Ddr7200",
+                                dimm_type: 4,
+                                dev_width: 2,
+                                rcd_manufacturer_id: 65535,
+                                rcd_generation: 0,
+                                raw_card_dev: 65535,
+                                dram_die_stepping_revision: 65535,
+                                dram_density: 255,
+                              },
+                              payload: {
+                                total_size: 80,
+                                qck_dev0: "Off",
+                                qck_dev1: "Off",
+                                qck_dev2: "Off",
+                                qck_dev3: "Off",
+                                qck_dev4: "40 Ω",
+                                qck_dev5: "Off",
+                                qck_dev6: "Off",
+                                qck_dev7: "Off",
+                                qck_dev8: "Off",
+                                qck_dev9: "40 Ω",
+                                qck_drive_strength: 1,
+                                qck_slew: "Default",
+                                qcs_dev0: "Off",
+                                qcs_dev1: "Off",
+                                qcs_dev2: "Off",
+                                qcs_dev3: "Off",
+                                qcs_dev4: "40 Ω",
+                                qcs_dev5: "Off",
+                                qcs_dev6: "Off",
+                                qcs_dev7: "Off",
+                                qcs_dev8: "Off",
+                                qcs_dev9: "40 Ω",
+                                qcs_drive_strength: 0,
+                                qcs_slew: "Default",
+                                qcs_vref: "66.0%",
+                                qca_dev0: "Off",
+                                qca_dev1: "Off",
+                                qca_dev2: "Off",
+                                qca_dev3: "Off",
+                                qca_dev4: "60 Ω",
+                                qca_dev5: "Off",
+                                qca_dev6: "Off",
+                                qca_dev7: "Off",
+                                qca_dev8: "Off",
+                                qca_dev9: "60 Ω",
+                                qca_drive_strength: 0,
+                                qca_slew: "Default",
+                                qca_vref: "69.5%"
+                              }
+                            },
+                            {
+                              header: {
+                                total_size: 32,
+                                mem_clk: "Ddr7200",
+                                dimm_type: 255,
+                                dev_width: 255,
+                                rcd_manufacturer_id: 65535,
+                                rcd_generation: 0,
+                                raw_card_dev: 65535,
+                                dram_die_stepping_revision: 65535,
+                                dram_density: 255,
+                              },
+                              payload: {
+                                total_size: 80,
+                                qck_dev0: "Off",
+                                qck_dev1: "Off",
+                                qck_dev2: "Off",
+                                qck_dev3: "Off",
+                                qck_dev4: "40 Ω",
+                                qck_dev5: "Off",
+                                qck_dev6: "Off",
+                                qck_dev7: "Off",
+                                qck_dev8: "Off",
+                                qck_dev9: "40 Ω",
+                                qck_drive_strength: 1,
+                                qck_slew: "Default",
+                                qcs_dev0: "Off",
+                                qcs_dev1: "Off",
+                                qcs_dev2: "Off",
+                                qcs_dev3: "Off",
+                                qcs_dev4: "40 Ω",
+                                qcs_dev5: "Off",
+                                qcs_dev6: "Off",
+                                qcs_dev7: "Off",
+                                qcs_dev8: "Off",
+                                qcs_dev9: "40 Ω",
+                                qcs_drive_strength: 0,
+                                qcs_slew: "Default",
+                                qcs_vref: "66.0%",
+                                qca_dev0: "Off",
+                                qca_dev1: "Off",
+                                qca_dev2: "Off",
+                                qca_dev3: "Off",
+                                qca_dev4: "60 Ω",
+                                qca_dev5: "Off",
+                                qca_dev6: "Off",
+                                qca_dev7: "Off",
+                                qca_dev8: "Off",
+                                qca_dev9: "60 Ω",
+                                qca_drive_strength: 0,
+                                qca_slew: "Default",
+                                qca_vref: "69.5%"
+                              }
+                            },
+                            {
+                              header: {
+                                total_size: 32,
+                                mem_clk: "Ddr7200",
+                                dimm_type: 2,
+                                dev_width: 2,
+                                rcd_manufacturer_id: 65535,
+                                rcd_generation: 1,
+                                raw_card_dev: 65535,
+                                dram_die_stepping_revision: 65535,
+                                dram_density: 255,
+                              },
+                              payload: {
+                                total_size: 80,
+                                qck_dev0: "Off",
+                                qck_dev1: "Off",
+                                qck_dev2: "Off",
+                                qck_dev3: "Off",
+                                qck_dev4: "40 Ω",
+                                qck_dev5: "Off",
+                                qck_dev6: "Off",
+                                qck_dev7: "Off",
+                                qck_dev8: "Off",
+                                qck_dev9: "40 Ω",
+                                qck_drive_strength: 1,
+                                qck_slew: "Default",
+                                qcs_dev0: "Off",
+                                qcs_dev1: "Off",
+                                qcs_dev2: "Off",
+                                qcs_dev3: "Off",
+                                qcs_dev4: "40 Ω",
+                                qcs_dev5: "Off",
+                                qcs_dev6: "Off",
+                                qcs_dev7: "Off",
+                                qcs_dev8: "Off",
+                                qcs_dev9: "40 Ω",
+                                qcs_drive_strength: 0,
+                                qcs_slew: "Default",
+                                qcs_vref: "66.0%",
+                                qca_dev0: "240 Ω",
+                                qca_dev1: "240 Ω",
+                                qca_dev2: "240 Ω",
+                                qca_dev3: "240 Ω",
+                                qca_dev4: "60 Ω",
+                                qca_dev5: "240 Ω",
+                                qca_dev6: "240 Ω",
+                                qca_dev7: "240 Ω",
+                                qca_dev8: "240 Ω",
+                                qca_dev9: "60 Ω",
+                                qca_drive_strength: 0,
+                                qca_slew: "Default",
+                                qca_vref: "69.5%"
+                              }
+                            },
+                            {
+                              header: {
+                                total_size: 32,
+                                mem_clk: "Ddr7200",
+                                dimm_type: 2,
+                                dev_width: 1,
+                                rcd_manufacturer_id: 65535,
+                                rcd_generation: 1,
+                                raw_card_dev: 65535,
+                                dram_die_stepping_revision: 65535,
+                                dram_density: 255,
+                              },
+                              payload: {
+                                total_size: 80,
+                                qck_dev0: "Off",
+                                qck_dev1: "Off",
+                                qck_dev2: "Off",
+                                qck_dev3: "Off",
+                                qck_dev4: "40 Ω",
+                                qck_dev5: "Off",
+                                qck_dev6: "Off",
+                                qck_dev7: "Off",
+                                qck_dev8: "Off",
+                                qck_dev9: "40 Ω",
+                                qck_drive_strength: 1,
+                                qck_slew: "Default",
+                                qcs_dev0: "Off",
+                                qcs_dev1: "Off",
+                                qcs_dev2: "Off",
+                                qcs_dev3: "Off",
+                                qcs_dev4: "40 Ω",
+                                qcs_dev5: "Off",
+                                qcs_dev6: "Off",
+                                qcs_dev7: "Off",
+                                qcs_dev8: "Off",
+                                qcs_dev9: "40 Ω",
+                                qcs_drive_strength: 0,
+                                qcs_slew: "Default",
+                                qcs_vref: "66.0%",
+                                qca_dev0: "Off",
+                                qca_dev1: "Off",
+                                qca_dev2: "Off",
+                                qca_dev3: "Off",
+                                qca_dev4: "60 Ω",
+                                qca_dev5: "Off",
+                                qca_dev6: "Off",
+                                qca_dev7: "Off",
+                                qca_dev8: "Off",
+                                qca_dev9: "60 Ω",
+                                qca_drive_strength: 0,
+                                qca_slew: "Default",
+                                qca_vref: "69.5%"
+                              }
+                            },
+                            {
+                              header: {
+                                total_size: 32,
+                                mem_clk: "Ddr7200",
+                                dimm_type: 4,
+                                dev_width: 2,
+                                rcd_manufacturer_id: 65535,
+                                rcd_generation: 1,
+                                raw_card_dev: 65535,
+                                dram_die_stepping_revision: 65535,
+                                dram_density: 255,
+                              },
+                              payload: {
+                                total_size: 80,
+                                qck_dev0: "Off",
+                                qck_dev1: "Off",
+                                qck_dev2: "Off",
+                                qck_dev3: "Off",
+                                qck_dev4: "40 Ω",
+                                qck_dev5: "Off",
+                                qck_dev6: "Off",
+                                qck_dev7: "Off",
+                                qck_dev8: "Off",
+                                qck_dev9: "40 Ω",
+                                qck_drive_strength: 1,
+                                qck_slew: "Default",
+                                qcs_dev0: "Off",
+                                qcs_dev1: "Off",
+                                qcs_dev2: "Off",
+                                qcs_dev3: "Off",
+                                qcs_dev4: "40 Ω",
+                                qcs_dev5: "Off",
+                                qcs_dev6: "Off",
+                                qcs_dev7: "Off",
+                                qcs_dev8: "Off",
+                                qcs_dev9: "40 Ω",
+                                qcs_drive_strength: 0,
+                                qcs_slew: "Default",
+                                qcs_vref: "66.0%",
+                                qca_dev0: "Off",
+                                qca_dev1: "Off",
+                                qca_dev2: "Off",
+                                qca_dev3: "Off",
+                                qca_dev4: "60 Ω",
+                                qca_dev5: "Off",
+                                qca_dev6: "Off",
+                                qca_dev7: "Off",
+                                qca_dev8: "Off",
+                                qca_dev9: "60 Ω",
+                                qca_drive_strength: 0,
+                                qca_slew: "Default",
+                                qca_vref: "69.5%"
+                              }
+                            },
+                            {
+                              header: {
+                                total_size: 32,
+                                mem_clk: "Ddr7200",
+                                dimm_type: 255,
+                                dev_width: 255,
+                                rcd_manufacturer_id: 65535,
+                                rcd_generation: 1,
+                                raw_card_dev: 65535,
+                                dram_die_stepping_revision: 65535,
+                                dram_density: 255,
+                              },
+                              payload: {
+                                total_size: 80,
+                                qck_dev0: "Off",
+                                qck_dev1: "Off",
+                                qck_dev2: "Off",
+                                qck_dev3: "Off",
+                                qck_dev4: "40 Ω",
+                                qck_dev5: "Off",
+                                qck_dev6: "Off",
+                                qck_dev7: "Off",
+                                qck_dev8: "Off",
+                                qck_dev9: "40 Ω",
+                                qck_drive_strength: 1,
+                                qck_slew: "Default",
+                                qcs_dev0: "Off",
+                                qcs_dev1: "Off",
+                                qcs_dev2: "Off",
+                                qcs_dev3: "Off",
+                                qcs_dev4: "40 Ω",
+                                qcs_dev5: "Off",
+                                qcs_dev6: "Off",
+                                qcs_dev7: "Off",
+                                qcs_dev8: "Off",
+                                qcs_dev9: "40 Ω",
+                                qcs_drive_strength: 0,
+                                qcs_slew: "Default",
+                                qcs_vref: "66.0%",
+                                qca_dev0: "Off",
+                                qca_dev1: "Off",
+                                qca_dev2: "Off",
+                                qca_dev3: "Off",
+                                qca_dev4: "60 Ω",
+                                qca_dev5: "Off",
+                                qca_dev6: "Off",
+                                qca_dev7: "Off",
+                                qca_dev8: "Off",
+                                qca_dev9: "60 Ω",
+                                qca_drive_strength: 0,
+                                qca_slew: "Default",
+                                qca_vref: "69.5%"
+                              }
+                            },
+                            {
+                              header: {
+                                total_size: 32,
+                                mem_clk: "Ddr7200",
+                                dimm_type: 2,
+                                dev_width: 2,
+                                rcd_manufacturer_id: 65535,
+                                rcd_generation: 255,
+                                raw_card_dev: 65535,
+                                dram_die_stepping_revision: 65535,
+                                dram_density: 255,
+                              },
+                              payload: {
+                                total_size: 80,
+                                qck_dev0: "Off",
+                                qck_dev1: "Off",
+                                qck_dev2: "Off",
+                                qck_dev3: "Off",
+                                qck_dev4: "80 Ω",
+                                qck_dev5: "Off",
+                                qck_dev6: "Off",
+                                qck_dev7: "Off",
+                                qck_dev8: "Off",
+                                qck_dev9: "80 Ω",
+                                qck_drive_strength: 2,
+                                qck_slew: "Fast",
+                                qcs_dev0: "Off",
+                                qcs_dev1: "240 Ω",
+                                qcs_dev2: "Off",
+                                qcs_dev3: "Off",
+                                qcs_dev4: "40 Ω",
+                                qcs_dev5: "Off",
+                                qcs_dev6: "240 Ω",
+                                qcs_dev7: "Off",
+                                qcs_dev8: "Off",
+                                qcs_dev9: "40 Ω",
+                                qcs_drive_strength: 1,
+                                qcs_slew: "Fast",
+                                qcs_vref: "68.0%",
+                                qca_dev0: "Off",
+                                qca_dev1: "Off",
+                                qca_dev2: "Off",
+                                qca_dev3: "Off",
+                                qca_dev4: "40 Ω",
+                                qca_dev5: "Off",
+                                qca_dev6: "Off",
+                                qca_dev7: "Off",
+                                qca_dev8: "Off",
+                                qca_dev9: "40 Ω",
+                                qca_drive_strength: 1,
+                                qca_slew: "Fast",
+                                qca_vref: "70.0%"
+                              }
+                            },
+                            {
+                              header: {
+                                total_size: 32,
+                                mem_clk: "Ddr7200",
+                                dimm_type: 2,
+                                dev_width: 1,
+                                rcd_manufacturer_id: 65535,
+                                rcd_generation: 255,
+                                raw_card_dev: 65535,
+                                dram_die_stepping_revision: 65535,
+                                dram_density: 255,
+                              },
+                              payload: {
+                                total_size: 80,
+                                qck_dev0: "Off",
+                                qck_dev1: "Off",
+                                qck_dev2: "Off",
+                                qck_dev3: "Off",
+                                qck_dev4: "80 Ω",
+                                qck_dev5: "Off",
+                                qck_dev6: "Off",
+                                qck_dev7: "Off",
+                                qck_dev8: "Off",
+                                qck_dev9: "80 Ω",
+                                qck_drive_strength: 2,
+                                qck_slew: "Fast",
+                                qcs_dev0: "Off",
+                                qcs_dev1: "240 Ω",
+                                qcs_dev2: "Off",
+                                qcs_dev3: "Off",
+                                qcs_dev4: "40 Ω",
+                                qcs_dev5: "Off",
+                                qcs_dev6: "240 Ω",
+                                qcs_dev7: "Off",
+                                qcs_dev8: "Off",
+                                qcs_dev9: "40 Ω",
+                                qcs_drive_strength: 1,
+                                qcs_slew: "Fast",
+                                qcs_vref: "68.0%",
+                                qca_dev0: "Off",
+                                qca_dev1: "Off",
+                                qca_dev2: "Off",
+                                qca_dev3: "Off",
+                                qca_dev4: "40 Ω",
+                                qca_dev5: "Off",
+                                qca_dev6: "Off",
+                                qca_dev7: "Off",
+                                qca_dev8: "Off",
+                                qca_dev9: "40 Ω",
+                                qca_drive_strength: 1,
+                                qca_slew: "Fast",
+                                qca_vref: "77.0%"
+                              }
+                            },
+                            {
+                              header: {
+                                total_size: 32,
+                                mem_clk: "Ddr7200",
+                                dimm_type: 4,
+                                dev_width: 2,
+                                rcd_manufacturer_id: 65535,
+                                rcd_generation: 255,
+                                raw_card_dev: 65535,
+                                dram_die_stepping_revision: 65535,
+                                dram_density: 255,
+                              },
+                              payload: {
+                                total_size: 80,
+                                qck_dev0: "Off",
+                                qck_dev1: "Off",
+                                qck_dev2: "Off",
+                                qck_dev3: "Off",
+                                qck_dev4: "80 Ω",
+                                qck_dev5: "Off",
+                                qck_dev6: "Off",
+                                qck_dev7: "Off",
+                                qck_dev8: "Off",
+                                qck_dev9: "80 Ω",
+                                qck_drive_strength: 2,
+                                qck_slew: "Fast",
+                                qcs_dev0: "Off",
+                                qcs_dev1: "240 Ω",
+                                qcs_dev2: "Off",
+                                qcs_dev3: "Off",
+                                qcs_dev4: "40 Ω",
+                                qcs_dev5: "Off",
+                                qcs_dev6: "240 Ω",
+                                qcs_dev7: "Off",
+                                qcs_dev8: "Off",
+                                qcs_dev9: "40 Ω",
+                                qcs_drive_strength: 1,
+                                qcs_slew: "Fast",
+                                qcs_vref: "68.0%",
+                                qca_dev0: "Off",
+                                qca_dev1: "Off",
+                                qca_dev2: "Off",
+                                qca_dev3: "Off",
+                                qca_dev4: "40 Ω",
+                                qca_dev5: "Off",
+                                qca_dev6: "Off",
+                                qca_dev7: "Off",
+                                qca_dev8: "Off",
+                                qca_dev9: "40 Ω",
+                                qca_drive_strength: 1,
+                                qca_slew: "Fast",
+                                qca_vref: "77.0%"
+                              }
+                            },
+                            {
+                              header: {
+                                total_size: 32,
+                                mem_clk: "Ddr7200",
+                                dimm_type: 255,
+                                dev_width: 255,
+                                rcd_manufacturer_id: 65535,
+                                rcd_generation: 255,
+                                raw_card_dev: 65535,
+                                dram_die_stepping_revision: 65535,
+                                dram_density: 255,
+                              },
+                              payload: {
+                                total_size: 80,
+                                qck_dev0: "Off",
+                                qck_dev1: "Off",
+                                qck_dev2: "Off",
+                                qck_dev3: "Off",
+                                qck_dev4: "80 Ω",
+                                qck_dev5: "Off",
+                                qck_dev6: "Off",
+                                qck_dev7: "Off",
+                                qck_dev8: "Off",
+                                qck_dev9: "80 Ω",
+                                qck_drive_strength: 2,
+                                qck_slew: "Fast",
+                                qcs_dev0: "Off",
+                                qcs_dev1: "240 Ω",
+                                qcs_dev2: "Off",
+                                qcs_dev3: "Off",
+                                qcs_dev4: "40 Ω",
+                                qcs_dev5: "Off",
+                                qcs_dev6: "240 Ω",
+                                qcs_dev7: "Off",
+                                qcs_dev8: "Off",
+                                qcs_dev9: "40 Ω",
+                                qcs_drive_strength: 1,
+                                qcs_slew: "Fast",
+                                qcs_vref: "68.0%",
+                                qca_dev0: "Off",
+                                qca_dev1: "Off",
+                                qca_dev2: "Off",
+                                qca_dev3: "Off",
+                                qca_dev4: "40 Ω",
+                                qca_dev5: "Off",
+                                qca_dev6: "Off",
+                                qca_dev7: "Off",
+                                qca_dev8: "Off",
+                                qca_dev9: "40 Ω",
+                                qca_drive_strength: 1,
+                                qca_slew: "Fast",
+                                qca_vref: "77.0%"
+                              }
+                            }
+                          ]
+                        },
+                        {
+                          header: {
+                            group_id: 5892,
+                            entry_id: 162,
+                            instance_id: 52864,
+                            context_type: "Struct",
+                            context_format: "Raw",
+                            unit_size: 0,
+                            priority_mask: {
+                              hard_force: false,
+                              high: false,
+                              medium: false,
+                              event_logging: false,
+                              low: false,
+                              normal: true,
+                            },
+                            key_size: 0,
+                            key_pos: 0,
+                            board_instance_mask: 65535
+                          },
+                          Ddr5RawCardConfigElement: [
+                            {
+                              header: {
+                                total_size: 32,
+                                mem_clk: "Ddr5600",
+                                dimm_type: 2,
+                                dev_width: 2,
+                                rcd_manufacturer_id: 65535,
+                                rcd_generation: 0,
+                                raw_card_dev: 65535,
+                                dram_die_stepping_revision: 65535,
+                                dram_density: 255,
+                              },
+                              payload: {
+                                total_size: 80,
+                                qck_dev0: "Off",
+                                qck_dev1: "Off",
+                                qck_dev2: "Off",
+                                qck_dev3: "Off",
+                                qck_dev4: "60 Ω",
+                                qck_dev5: "Off",
+                                qck_dev6: "Off",
+                                qck_dev7: "Off",
+                                qck_dev8: "Off",
+                                qck_dev9: "60 Ω",
+                                qck_drive_strength: 1,
+                                qck_slew: "Moderate",
+                                qcs_dev0: "Off",
+                                qcs_dev1: "Off",
+                                qcs_dev2: "Off",
+                                qcs_dev3: "Off",
+                                qcs_dev4: "40 Ω",
+                                qcs_dev5: "Off",
+                                qcs_dev6: "Off",
+                                qcs_dev7: "Off",
+                                qcs_dev8: "Off",
+                                qcs_dev9: "40 Ω",
+                                qcs_drive_strength: 0,
+                                qcs_slew: "Moderate",
+                                qcs_vref: "66.0%",
+                                qca_dev0: "Off",
+                                qca_dev1: "Off",
+                                qca_dev2: "Off",
+                                qca_dev3: "Off",
+                                qca_dev4: "40 Ω",
+                                qca_dev5: "Off",
+                                qca_dev6: "Off",
+                                qca_dev7: "Off",
+                                qca_dev8: "Off",
+                                qca_dev9: "40 Ω",
+                                qca_drive_strength: 0,
+                                qca_slew: "Moderate",
+                                qca_vref: "69.5%"
+                              }
+                            },
+                            {
+                              header: {
+                                total_size: 32,
+                                mem_clk: "Ddr5600",
+                                dimm_type: 2,
+                                dev_width: 1,
+                                rcd_manufacturer_id: 65535,
+                                rcd_generation: 0,
+                                raw_card_dev: 65535,
+                                dram_die_stepping_revision: 65535,
+                                dram_density: 255,
+                              },
+                              payload: {
+                                total_size: 80,
+                                qck_dev0: "Off",
+                                qck_dev1: "Off",
+                                qck_dev2: "Off",
+                                qck_dev3: "Off",
+                                qck_dev4: "60 Ω",
+                                qck_dev5: "Off",
+                                qck_dev6: "Off",
+                                qck_dev7: "Off",
+                                qck_dev8: "Off",
+                                qck_dev9: "60 Ω",
+                                qck_drive_strength: 1,
+                                qck_slew: "Moderate",
+                                qcs_dev0: "Off",
+                                qcs_dev1: "Off",
+                                qcs_dev2: "Off",
+                                qcs_dev3: "Off",
+                                qcs_dev4: "40 Ω",
+                                qcs_dev5: "Off",
+                                qcs_dev6: "Off",
+                                qcs_dev7: "Off",
+                                qcs_dev8: "Off",
+                                qcs_dev9: "40 Ω",
+                                qcs_drive_strength: 0,
+                                qcs_slew: "Moderate",
+                                qcs_vref: "66.0%",
+                                qca_dev0: "Off",
+                                qca_dev1: "Off",
+                                qca_dev2: "Off",
+                                qca_dev3: "Off",
+                                qca_dev4: "60 Ω",
+                                qca_dev5: "Off",
+                                qca_dev6: "Off",
+                                qca_dev7: "Off",
+                                qca_dev8: "Off",
+                                qca_dev9: "60 Ω",
+                                qca_drive_strength: 1,
+                                qca_slew: "Moderate",
+                                qca_vref: "69.5%"
+                              }
+                            },
+                            {
+                              header: {
+                                total_size: 32,
+                                mem_clk: "Ddr5600",
+                                dimm_type: 4,
+                                dev_width: 2,
+                                rcd_manufacturer_id: 65535,
+                                rcd_generation: 0,
+                                raw_card_dev: 65535,
+                                dram_die_stepping_revision: 65535,
+                                dram_density: 255,
+                              },
+                              payload: {
+                                total_size: 80,
+                                qck_dev0: "Off",
+                                qck_dev1: "Off",
+                                qck_dev2: "Off",
+                                qck_dev3: "Off",
+                                qck_dev4: "60 Ω",
+                                qck_dev5: "Off",
+                                qck_dev6: "Off",
+                                qck_dev7: "Off",
+                                qck_dev8: "Off",
+                                qck_dev9: "60 Ω",
+                                qck_drive_strength: 1,
+                                qck_slew: "Moderate",
+                                qcs_dev0: "Off",
+                                qcs_dev1: "Off",
+                                qcs_dev2: "Off",
+                                qcs_dev3: "Off",
+                                qcs_dev4: "40 Ω",
+                                qcs_dev5: "Off",
+                                qcs_dev6: "Off",
+                                qcs_dev7: "Off",
+                                qcs_dev8: "Off",
+                                qcs_dev9: "40 Ω",
+                                qcs_drive_strength: 0,
+                                qcs_slew: "Moderate",
+                                qcs_vref: "66.0%",
+                                qca_dev0: "Off",
+                                qca_dev1: "Off",
+                                qca_dev2: "Off",
+                                qca_dev3: "Off",
+                                qca_dev4: "60 Ω",
+                                qca_dev5: "Off",
+                                qca_dev6: "Off",
+                                qca_dev7: "Off",
+                                qca_dev8: "Off",
+                                qca_dev9: "60 Ω",
+                                qca_drive_strength: 1,
+                                qca_slew: "Moderate",
+                                qca_vref: "69.5%"
+                              }
+                            },
+                            {
+                              header: {
+                                total_size: 32,
+                                mem_clk: "Ddr5600",
+                                dimm_type: 255,
+                                dev_width: 255,
+                                rcd_manufacturer_id: 65535,
+                                rcd_generation: 0,
+                                raw_card_dev: 65535,
+                                dram_die_stepping_revision: 65535,
+                                dram_density: 255,
+                              },
+                              payload: {
+                                total_size: 80,
+                                qck_dev0: "Off",
+                                qck_dev1: "Off",
+                                qck_dev2: "Off",
+                                qck_dev3: "Off",
+                                qck_dev4: "60 Ω",
+                                qck_dev5: "Off",
+                                qck_dev6: "Off",
+                                qck_dev7: "Off",
+                                qck_dev8: "Off",
+                                qck_dev9: "60 Ω",
+                                qck_drive_strength: 1,
+                                qck_slew: "Moderate",
+                                qcs_dev0: "Off",
+                                qcs_dev1: "Off",
+                                qcs_dev2: "Off",
+                                qcs_dev3: "Off",
+                                qcs_dev4: "40 Ω",
+                                qcs_dev5: "Off",
+                                qcs_dev6: "Off",
+                                qcs_dev7: "Off",
+                                qcs_dev8: "Off",
+                                qcs_dev9: "40 Ω",
+                                qcs_drive_strength: 0,
+                                qcs_slew: "Moderate",
+                                qcs_vref: "66.0%",
+                                qca_dev0: "Off",
+                                qca_dev1: "Off",
+                                qca_dev2: "Off",
+                                qca_dev3: "Off",
+                                qca_dev4: "60 Ω",
+                                qca_dev5: "Off",
+                                qca_dev6: "Off",
+                                qca_dev7: "Off",
+                                qca_dev8: "Off",
+                                qca_dev9: "60 Ω",
+                                qca_drive_strength: 1,
+                                qca_slew: "Moderate",
+                                qca_vref: "69.5%"
+                              }
+                            },
+                            {
+                              header: {
+                                total_size: 32,
+                                mem_clk: "Ddr5600",
+                                dimm_type: 2,
+                                dev_width: 2,
+                                rcd_manufacturer_id: 65535,
+                                rcd_generation: 1,
+                                raw_card_dev: 65535,
+                                dram_die_stepping_revision: 65535,
+                                dram_density: 255,
+                              },
+                              payload: {
+                                total_size: 80,
+                                qck_dev0: "Off",
+                                qck_dev1: "Off",
+                                qck_dev2: "Off",
+                                qck_dev3: "Off",
+                                qck_dev4: "60 Ω",
+                                qck_dev5: "Off",
+                                qck_dev6: "Off",
+                                qck_dev7: "Off",
+                                qck_dev8: "Off",
+                                qck_dev9: "60 Ω",
+                                qck_drive_strength: 1,
+                                qck_slew: "Moderate",
+                                qcs_dev0: "Off",
+                                qcs_dev1: "Off",
+                                qcs_dev2: "Off",
+                                qcs_dev3: "Off",
+                                qcs_dev4: "40 Ω",
+                                qcs_dev5: "Off",
+                                qcs_dev6: "Off",
+                                qcs_dev7: "Off",
+                                qcs_dev8: "Off",
+                                qcs_dev9: "40 Ω",
+                                qcs_drive_strength: 0,
+                                qcs_slew: "Moderate",
+                                qcs_vref: "66.0%",
+                                qca_dev0: "Off",
+                                qca_dev1: "Off",
+                                qca_dev2: "Off",
+                                qca_dev3: "Off",
+                                qca_dev4: "40 Ω",
+                                qca_dev5: "Off",
+                                qca_dev6: "Off",
+                                qca_dev7: "Off",
+                                qca_dev8: "Off",
+                                qca_dev9: "40 Ω",
+                                qca_drive_strength: 0,
+                                qca_slew: "Moderate",
+                                qca_vref: "69.5%"
+                              }
+                            },
+                            {
+                              header: {
+                                total_size: 32,
+                                mem_clk: "Ddr5600",
+                                dimm_type: 2,
+                                dev_width: 1,
+                                rcd_manufacturer_id: 65535,
+                                rcd_generation: 1,
+                                raw_card_dev: 65535,
+                                dram_die_stepping_revision: 65535,
+                                dram_density: 255,
+                              },
+                              payload: {
+                                total_size: 80,
+                                qck_dev0: "Off",
+                                qck_dev1: "Off",
+                                qck_dev2: "Off",
+                                qck_dev3: "Off",
+                                qck_dev4: "60 Ω",
+                                qck_dev5: "Off",
+                                qck_dev6: "Off",
+                                qck_dev7: "Off",
+                                qck_dev8: "Off",
+                                qck_dev9: "60 Ω",
+                                qck_drive_strength: 1,
+                                qck_slew: "Moderate",
+                                qcs_dev0: "Off",
+                                qcs_dev1: "Off",
+                                qcs_dev2: "Off",
+                                qcs_dev3: "Off",
+                                qcs_dev4: "40 Ω",
+                                qcs_dev5: "Off",
+                                qcs_dev6: "Off",
+                                qcs_dev7: "Off",
+                                qcs_dev8: "Off",
+                                qcs_dev9: "40 Ω",
+                                qcs_drive_strength: 0,
+                                qcs_slew: "Moderate",
+                                qcs_vref: "66.0%",
+                                qca_dev0: "Off",
+                                qca_dev1: "Off",
+                                qca_dev2: "Off",
+                                qca_dev3: "Off",
+                                qca_dev4: "60 Ω",
+                                qca_dev5: "Off",
+                                qca_dev6: "Off",
+                                qca_dev7: "Off",
+                                qca_dev8: "Off",
+                                qca_dev9: "60 Ω",
+                                qca_drive_strength: 1,
+                                qca_slew: "Moderate",
+                                qca_vref: "69.5%"
+                              }
+                            },
+                            {
+                              header: {
+                                total_size: 32,
+                                mem_clk: "Ddr5600",
+                                dimm_type: 4,
+                                dev_width: 2,
+                                rcd_manufacturer_id: 65535,
+                                rcd_generation: 1,
+                                raw_card_dev: 65535,
+                                dram_die_stepping_revision: 65535,
+                                dram_density: 255,
+                              },
+                              payload: {
+                                total_size: 80,
+                                qck_dev0: "Off",
+                                qck_dev1: "Off",
+                                qck_dev2: "Off",
+                                qck_dev3: "Off",
+                                qck_dev4: "60 Ω",
+                                qck_dev5: "Off",
+                                qck_dev6: "Off",
+                                qck_dev7: "Off",
+                                qck_dev8: "Off",
+                                qck_dev9: "60 Ω",
+                                qck_drive_strength: 1,
+                                qck_slew: "Moderate",
+                                qcs_dev0: "Off",
+                                qcs_dev1: "Off",
+                                qcs_dev2: "Off",
+                                qcs_dev3: "Off",
+                                qcs_dev4: "40 Ω",
+                                qcs_dev5: "Off",
+                                qcs_dev6: "Off",
+                                qcs_dev7: "Off",
+                                qcs_dev8: "Off",
+                                qcs_dev9: "40 Ω",
+                                qcs_drive_strength: 0,
+                                qcs_slew: "Moderate",
+                                qcs_vref: "66.0%",
+                                qca_dev0: "Off",
+                                qca_dev1: "Off",
+                                qca_dev2: "Off",
+                                qca_dev3: "Off",
+                                qca_dev4: "60 Ω",
+                                qca_dev5: "Off",
+                                qca_dev6: "Off",
+                                qca_dev7: "Off",
+                                qca_dev8: "Off",
+                                qca_dev9: "60 Ω",
+                                qca_drive_strength: 1,
+                                qca_slew: "Moderate",
+                                qca_vref: "69.5%"
+                              }
+                            },
+                            {
+                              header: {
+                                total_size: 32,
+                                mem_clk: "Ddr5600",
+                                dimm_type: 255,
+                                dev_width: 255,
+                                rcd_manufacturer_id: 65535,
+                                rcd_generation: 1,
+                                raw_card_dev: 65535,
+                                dram_die_stepping_revision: 65535,
+                                dram_density: 255,
+                              },
+                              payload: {
+                                total_size: 80,
+                                qck_dev0: "Off",
+                                qck_dev1: "Off",
+                                qck_dev2: "Off",
+                                qck_dev3: "Off",
+                                qck_dev4: "60 Ω",
+                                qck_dev5: "Off",
+                                qck_dev6: "Off",
+                                qck_dev7: "Off",
+                                qck_dev8: "Off",
+                                qck_dev9: "60 Ω",
+                                qck_drive_strength: 1,
+                                qck_slew: "Moderate",
+                                qcs_dev0: "Off",
+                                qcs_dev1: "Off",
+                                qcs_dev2: "Off",
+                                qcs_dev3: "Off",
+                                qcs_dev4: "40 Ω",
+                                qcs_dev5: "Off",
+                                qcs_dev6: "Off",
+                                qcs_dev7: "Off",
+                                qcs_dev8: "Off",
+                                qcs_dev9: "40 Ω",
+                                qcs_drive_strength: 0,
+                                qcs_slew: "Moderate",
+                                qcs_vref: "66.0%",
+                                qca_dev0: "Off",
+                                qca_dev1: "Off",
+                                qca_dev2: "Off",
+                                qca_dev3: "Off",
+                                qca_dev4: "60 Ω",
+                                qca_dev5: "Off",
+                                qca_dev6: "Off",
+                                qca_dev7: "Off",
+                                qca_dev8: "Off",
+                                qca_dev9: "60 Ω",
+                                qca_drive_strength: 1,
+                                qca_slew: "Moderate",
+                                qca_vref: "69.5%"
+                              }
+                            },
+                            {
+                              header: {
+                                total_size: 32,
+                                mem_clk: "Ddr7200",
+                                dimm_type: 2,
+                                dev_width: 2,
+                                rcd_manufacturer_id: 65535,
+                                rcd_generation: 255,
+                                raw_card_dev: 65535,
+                                dram_die_stepping_revision: 65535,
+                                dram_density: 255,
+                              },
+                              payload: {
+                                total_size: 80,
+                                qck_dev0: "Off",
+                                qck_dev1: "Off",
+                                qck_dev2: "Off",
+                                qck_dev3: "Off",
+                                qck_dev4: "60 Ω",
+                                qck_dev5: "Off",
+                                qck_dev6: "Off",
+                                qck_dev7: "Off",
+                                qck_dev8: "Off",
+                                qck_dev9: "60 Ω",
+                                qck_drive_strength: 2,
+                                qck_slew: "Moderate",
+                                qcs_dev0: "Off",
+                                qcs_dev1: "Off",
+                                qcs_dev2: "Off",
+                                qcs_dev3: "Off",
+                                qcs_dev4: "40 Ω",
+                                qcs_dev5: "Off",
+                                qcs_dev6: "Off",
+                                qcs_dev7: "Off",
+                                qcs_dev8: "Off",
+                                qcs_dev9: "40 Ω",
+                                qcs_drive_strength: 1,
+                                qcs_slew: "Moderate",
+                                qcs_vref: "66.0%",
+                                qca_dev0: "Off",
+                                qca_dev1: "Off",
+                                qca_dev2: "Off",
+                                qca_dev3: "Off",
+                                qca_dev4: "40 Ω",
+                                qca_dev5: "Off",
+                                qca_dev6: "Off",
+                                qca_dev7: "Off",
+                                qca_dev8: "Off",
+                                qca_dev9: "40 Ω",
+                                qca_drive_strength: 1,
+                                qca_slew: "Moderate",
+                                qca_vref: "69.5%"
+                              }
+                            },
+                            {
+                              header: {
+                                total_size: 32,
+                                mem_clk: "Ddr7200",
+                                dimm_type: 2,
+                                dev_width: 1,
+                                rcd_manufacturer_id: 65535,
+                                rcd_generation: 255,
+                                raw_card_dev: 65535,
+                                dram_die_stepping_revision: 65535,
+                                dram_density: 255,
+                              },
+                              payload: {
+                                total_size: 80,
+                                qck_dev0: "Off",
+                                qck_dev1: "Off",
+                                qck_dev2: "Off",
+                                qck_dev3: "Off",
+                                qck_dev4: "60 Ω",
+                                qck_dev5: "Off",
+                                qck_dev6: "Off",
+                                qck_dev7: "Off",
+                                qck_dev8: "Off",
+                                qck_dev9: "60 Ω",
+                                qck_drive_strength: 2,
+                                qck_slew: "Moderate",
+                                qcs_dev0: "Off",
+                                qcs_dev1: "Off",
+                                qcs_dev2: "Off",
+                                qcs_dev3: "Off",
+                                qcs_dev4: "40 Ω",
+                                qcs_dev5: "Off",
+                                qcs_dev6: "Off",
+                                qcs_dev7: "Off",
+                                qcs_dev8: "Off",
+                                qcs_dev9: "40 Ω",
+                                qcs_drive_strength: 1,
+                                qcs_slew: "Moderate",
+                                qcs_vref: "66.0%",
+                                qca_dev0: "Off",
+                                qca_dev1: "Off",
+                                qca_dev2: "Off",
+                                qca_dev3: "Off",
+                                qca_dev4: "40 Ω",
+                                qca_dev5: "Off",
+                                qca_dev6: "Off",
+                                qca_dev7: "Off",
+                                qca_dev8: "Off",
+                                qca_dev9: "40 Ω",
+                                qca_drive_strength: 1,
+                                qca_slew: "Moderate",
+                                qca_vref: "75.0%"
+                              }
+                            },
+                            {
+                              header: {
+                                total_size: 32,
+                                mem_clk: "Ddr7200",
+                                dimm_type: 4,
+                                dev_width: 2,
+                                rcd_manufacturer_id: 65535,
+                                rcd_generation: 255,
+                                raw_card_dev: 65535,
+                                dram_die_stepping_revision: 65535,
+                                dram_density: 255,
+                              },
+                              payload: {
+                                total_size: 80,
+                                qck_dev0: "Off",
+                                qck_dev1: "Off",
+                                qck_dev2: "Off",
+                                qck_dev3: "Off",
+                                qck_dev4: "60 Ω",
+                                qck_dev5: "Off",
+                                qck_dev6: "Off",
+                                qck_dev7: "Off",
+                                qck_dev8: "Off",
+                                qck_dev9: "60 Ω",
+                                qck_drive_strength: 2,
+                                qck_slew: "Moderate",
+                                qcs_dev0: "Off",
+                                qcs_dev1: "Off",
+                                qcs_dev2: "Off",
+                                qcs_dev3: "Off",
+                                qcs_dev4: "40 Ω",
+                                qcs_dev5: "Off",
+                                qcs_dev6: "Off",
+                                qcs_dev7: "Off",
+                                qcs_dev8: "Off",
+                                qcs_dev9: "40 Ω",
+                                qcs_drive_strength: 1,
+                                qcs_slew: "Moderate",
+                                qcs_vref: "66.0%",
+                                qca_dev0: "Off",
+                                qca_dev1: "Off",
+                                qca_dev2: "Off",
+                                qca_dev3: "Off",
+                                qca_dev4: "40 Ω",
+                                qca_dev5: "Off",
+                                qca_dev6: "Off",
+                                qca_dev7: "Off",
+                                qca_dev8: "Off",
+                                qca_dev9: "40 Ω",
+                                qca_drive_strength: 1,
+                                qca_slew: "Moderate",
+                                qca_vref: "75.0%"
+                              }
+                            },
+                            {
+                              header: {
+                                total_size: 32,
+                                mem_clk: "Ddr7200",
+                                dimm_type: 255,
+                                dev_width: 255,
+                                rcd_manufacturer_id: 65535,
+                                rcd_generation: 255,
+                                raw_card_dev: 65535,
+                                dram_die_stepping_revision: 65535,
+                                dram_density: 255,
+                              },
+                              payload: {
+                                total_size: 80,
+                                qck_dev0: "Off",
+                                qck_dev1: "Off",
+                                qck_dev2: "Off",
+                                qck_dev3: "Off",
+                                qck_dev4: "60 Ω",
+                                qck_dev5: "Off",
+                                qck_dev6: "Off",
+                                qck_dev7: "Off",
+                                qck_dev8: "Off",
+                                qck_dev9: "60 Ω",
+                                qck_drive_strength: 2,
+                                qck_slew: "Moderate",
+                                qcs_dev0: "Off",
+                                qcs_dev1: "Off",
+                                qcs_dev2: "Off",
+                                qcs_dev3: "Off",
+                                qcs_dev4: "40 Ω",
+                                qcs_dev5: "Off",
+                                qcs_dev6: "Off",
+                                qcs_dev7: "Off",
+                                qcs_dev8: "Off",
+                                qcs_dev9: "40 Ω",
+                                qcs_drive_strength: 1,
+                                qcs_slew: "Moderate",
+                                qcs_vref: "66.0%",
+                                qca_dev0: "Off",
+                                qca_dev1: "Off",
+                                qca_dev2: "Off",
+                                qca_dev3: "Off",
+                                qca_dev4: "40 Ω",
+                                qca_dev5: "Off",
+                                qca_dev6: "Off",
+                                qca_dev7: "Off",
+                                qca_dev8: "Off",
+                                qca_dev9: "40 Ω",
+                                qca_drive_strength: 1,
+                                qca_slew: "Moderate",
+                                qca_vref: "75.0%"
+                              }
+                            }
+                          ]
+                        },
+                        {
+                          header: {
+                            group_id: 5892,
+                            entry_id: 163,
+                            instance_id: 0,
+                            context_type: "Struct",
+                            context_format: "Raw",
+                            unit_size: 0,
+                            priority_mask: {
+                              normal: true,
+                            },
+                            key_size: 0,
+                            key_pos: 0,
+                            board_instance_mask: 65535
+                          },
+                          MaxFreqElement: [
+                            {
+                              dimm_slots_per_channel: {
+                                Specific: {
+                                  one_dimm: true,
+                                  two_dimms: false,
+                                  three_dimms: false,
+                                  four_dimms: false,
+                                }
+                              },
+                              conditions: [
+                                1,
+                                1,
+                                0,
+                                0
+                              ],
+                              speeds: [
+                                3200,
+                                4401,
+                                4401
+                              ]
+                            },
+                            {
+                              dimm_slots_per_channel: {
+                                Specific: {
+                                  one_dimm: true,
+                                  two_dimms: false,
+                                  three_dimms: false,
+                                  four_dimms: false,
+                                }
+                              },
+                              conditions: [
+                                1,
+                                0,
+                                1,
+                                0
+                              ],
+                              speeds: [
+                                3200,
+                                4401,
+                                4401
+                              ]
+                            },
+                            {
+                              dimm_slots_per_channel: {
+                                Specific: {
+                                  one_dimm: false,
+                                  two_dimms: true,
+                                  three_dimms: false,
+                                  four_dimms: false,
+                                }
+                              },
+                              conditions: [
+                                1,
+                                1,
+                                0,
+                                0
+                              ],
+                              speeds: [
+                                2600,
+                                4401,
+                                4401
+                              ]
+                            },
+                            {
+                              dimm_slots_per_channel: {
+                                Specific: {
+                                  one_dimm: false,
+                                  two_dimms: true,
+                                  three_dimms: false,
+                                  four_dimms: false,
+                                }
+                              },
+                              conditions: [
+                                1,
+                                0,
+                                1,
+                                0
+                              ],
+                              speeds: [
+                                2600,
+                                4401,
+                                4401
+                              ]
+                            },
+                            {
+                              dimm_slots_per_channel: {
+                                Specific: {
+                                  one_dimm: false,
+                                  two_dimms: true,
+                                  three_dimms: false,
+                                  four_dimms: false,
+                                }
+                              },
+                              conditions: [
+                                2,
+                                2,
+                                0,
+                                0
+                              ],
+                              speeds: [
+                                2200,
+                                4401,
+                                4401
+                              ]
+                            },
+                            {
+                              dimm_slots_per_channel: {
+                                Specific: {
+                                  one_dimm: false,
+                                  two_dimms: true,
+                                  three_dimms: false,
+                                  four_dimms: false,
+                                }
+                              },
+                              conditions: [
+                                2,
+                                0,
+                                2,
+                                0
+                              ],
+                              speeds: [
+                                2000,
+                                4401,
+                                4401
+                              ]
+                            }
+                          ]
+                        },
+                        {
+                          header: {
+                            group_id: 5893,
+                            entry_id: 4099,
+                            instance_id: 0,
+                            context_type: "Struct",
+                            context_format: "Raw",
+                            unit_size: 0,
+                            priority_mask: {
+                              hard_force: false,
+                              high: false,
+                              medium: false,
+                              event_logging: false,
+                              low: false,
+                              normal: true,
+                            },
+                            key_size: 0,
+                            key_pos: 0,
+                            board_instance_mask: 1
+                          },
+                          EarlyPcieConfigElement: [
+                            {
+                              start_lane: 255,
+                              end_lane: 255,
+                              socket: 0,
+                              port_present: false,
+                              link_speed: "Gen3",
+                              reset_pin: "None",
+                              root_function: 0,
+                              root_device: 0,
+                              max_payload: 255,
+                              tx_deemphasis: 255,
+                            },
+                            {
+                              start_lane: 255,
+                              end_lane: 255,
+                              socket: 0,
+                              port_present: false,
+                              link_speed: "Gen3",
+                              reset_pin: "None",
+                              root_function: 0,
+                              root_device: 0,
+                              max_payload: 255,
+                              tx_deemphasis: 255,
+                            },
+                            {
+                              start_lane: 255,
+                              end_lane: 255,
+                              socket: 0,
+                              port_present: false,
+                              link_speed: "Gen3",
+                              reset_pin: "None",
+                              root_function: 0,
+                              root_device: 0,
+                              max_payload: 255,
+                              tx_deemphasis: 255,
+                            },
+                            {
+                              start_lane: 255,
+                              end_lane: 255,
+                              socket: 0,
+                              port_present: false,
+                              link_speed: "Gen3",
+                              reset_pin: "None",
+                              root_function: 0,
+                              root_device: 0,
+                              max_payload: 255,
+                              tx_deemphasis: 255,
+                            },
+                            {
+                              start_lane: 255,
+                              end_lane: 255,
+                              socket: 0,
+                              port_present: false,
+                              link_speed: "Gen3",
+                              reset_pin: "None",
+                              root_function: 0,
+                              root_device: 0,
+                              max_payload: 255,
+                              tx_deemphasis: 255,
+                            },
+                            {
+                              start_lane: 255,
+                              end_lane: 255,
+                              socket: 0,
+                              port_present: false,
+                              link_speed: "Gen3",
+                              reset_pin: "None",
+                              root_function: 0,
+                              root_device: 0,
+                              max_payload: 255,
+                              tx_deemphasis: 255,
+                            },
+                            {
+                              start_lane: 255,
+                              end_lane: 255,
+                              socket: 0,
+                              port_present: false,
+                              link_speed: "Gen3",
+                              reset_pin: "None",
+                              root_function: 0,
+                              root_device: 0,
+                              max_payload: 255,
+                              tx_deemphasis: 255,
+                            },
+                            {
+                              start_lane: 255,
+                              end_lane: 255,
+                              socket: 0,
+                              port_present: false,
+                              link_speed: "Gen3",
+                              reset_pin: "None",
+                              root_function: 0,
+                              root_device: 0,
+                              max_payload: 255,
+                              tx_deemphasis: 255,
+                            }
+                          ]
+                        },
+                        {
+                          header: {
+                            group_id: 5893,
+                            entry_id: 4099,
+                            instance_id: 0,
+                            context_type: "Struct",
+                            context_format: "Raw",
+                            unit_size: 0,
+                            priority_mask: {
+                              hard_force: false,
+                              high: false,
+                              medium: false,
+                              event_logging: false,
+                              low: false,
+                              normal: true,
+                            },
+                            key_size: 0,
+                            key_pos: 0,
+                            board_instance_mask: 65535
+                          },
+                          EarlyPcieConfigElement: [
+                            {
+                              start_lane: 255,
+                              end_lane: 255,
+                              socket: 0,
+                              port_present: false,
+                              link_speed: "Gen3",
+                              reset_pin: "None",
+                              root_function: 0,
+                              root_device: 0,
+                              max_payload: 255,
+                              tx_deemphasis: 255,
+                            },
+                            {
+                              start_lane: 255,
+                              end_lane: 255,
+                              socket: 0,
+                              port_present: false,
+                              link_speed: "Gen3",
+                              reset_pin: "None",
+                              root_function: 0,
+                              root_device: 0,
+                              max_payload: 255,
+                              tx_deemphasis: 255,
+                            },
+                            {
+                              start_lane: 255,
+                              end_lane: 255,
+                              socket: 0,
+                              port_present: false,
+                              link_speed: "Gen3",
+                              reset_pin: "None",
+                              root_function: 0,
+                              root_device: 0,
+                              max_payload: 255,
+                              tx_deemphasis: 255,
+                            },
+                            {
+                              start_lane: 255,
+                              end_lane: 255,
+                              socket: 0,
+                              port_present: false,
+                              link_speed: "Gen3",
+                              reset_pin: "None",
+                              root_function: 0,
+                              root_device: 0,
+                              max_payload: 255,
+                              tx_deemphasis: 255,
+                            },
+                            {
+                              start_lane: 255,
+                              end_lane: 255,
+                              socket: 0,
+                              port_present: false,
+                              link_speed: "Gen3",
+                              reset_pin: "None",
+                              root_function: 0,
+                              root_device: 0,
+                              max_payload: 255,
+                              tx_deemphasis: 255,
+                            },
+                            {
+                              start_lane: 255,
+                              end_lane: 255,
+                              socket: 0,
+                              port_present: false,
+                              link_speed: "Gen3",
+                              reset_pin: "None",
+                              root_function: 0,
+                              root_device: 0,
+                              max_payload: 255,
+                              tx_deemphasis: 255,
+                            },
+                            {
+                              start_lane: 255,
+                              end_lane: 255,
+                              socket: 0,
+                              port_present: false,
+                              link_speed: "Gen3",
+                              reset_pin: "None",
+                              root_function: 0,
+                              root_device: 0,
+                              max_payload: 255,
+                              tx_deemphasis: 255,
+                            },
+                            {
+                              start_lane: 255,
+                              end_lane: 255,
+                              socket: 0,
+                              port_present: false,
+                              link_speed: "Gen3",
+                              reset_pin: "None",
+                              root_function: 0,
+                              root_device: 0,
+                              max_payload: 255,
+                              tx_deemphasis: 255,
+                            }
+                          ]
+                        },
+                        {
+                          header: {
+                            group_id: 5894,
+                            entry_id: 8193,
+                            instance_id: 0,
+                            context_type: "Struct",
+                            context_format: "Raw",
+                            unit_size: 0,
+                            priority_mask: {
+                              hard_force: false,
+                              high: false,
+                              medium: false,
+                              event_logging: false,
+                              low: false,
+                              normal: true,
+                            },
+                            key_size: 0,
+                            key_pos: 0,
+                            board_instance_mask: 65535
+                          },
+                          EspiInit: {
+                            espi_enabled: true,
+                            data_bus_select: "OutputHigh",
+                            clock_pin_select: "Gpio86",
+                            cs_pin_select: "Gpio30",
+                            clock_frequency: "16.66 MHz",
+                            io_mode: "Quad",
+                            alert_mode: "DedicatedAlertPin",
+                            pltrst_deassert: false,
+                            io80_decoding_enabled: true,
+                            io6064_decoding_enabled: true,
+                            io_range_sizes_minus_one: [
+                              3,
+                              7,
+                              7,
+                              0,
+                              0,
+                              0,
+                              0,
+                              0,
+                              0,
+                              0,
+                              0,
+                              0,
+                              0,
+                              0,
+                              0,
+                              0
+                            ],
+                            io_range_bases: [
+                              3234,
+                              760,
+                              1016,
+                              0,
+                              0,
+                              0,
+                              0,
+                              0,
+                              0,
+                              0,
+                              0,
+                              0,
+                              0,
+                              0,
+                              0,
+                              0
+                            ],
+                            mmio_range_sizes_minus_one: [
+                              0,
+                              0,
+                              0,
+                              0,
+                              0
+                            ],
+                            mmio_range_bases: [
+                              0,
+                              0,
+                              0,
+                              0,
+                              0
+                            ],
+                            irq_mask: 4294967295,
+                            irq_polarity: 0,
+                            cputemp_rtctime_vw_enabled: false,
+                            cputemp_rtctime_vw_index_select: 0,
+                            cpu_temp_mmio_base: 0,
+                            rtc_time_mmio_base: 0,
+                            bus_master_enabled: true,
+                          }
+                        },
+                        {
+                          header: {
+                            group_id: 5894,
+                            entry_id: 8197,
+                            instance_id: 0,
+                            context_type: "Struct",
+                            context_format: "Raw",
+                            unit_size: 0,
+                            priority_mask: {
+                              hard_force: false,
+                              high: false,
+                              medium: false,
+                              event_logging: false,
+                              low: false,
+                              normal: true,
+                            },
+                            key_size: 0,
+                            key_pos: 0,
+                            board_instance_mask: 65535
+                          },
+                          EspiSioInitElement: [
+                            {
+                              io_port: 0,
+                              access_width: "Terminator",
+                              data_mask: 0,
+                              data_or: 0
+                            }
+                          ]
+                        },
+                        {
+                          header: {
+                            group_id: 12288,
+                            entry_id: 0,
+                            instance_id: 0,
+                            context_type: "Tokens",
+                            context_format: "SortAscending",
+                            unit_size: 8,
+                            priority_mask: {
+                              hard_force: false,
+                              high: false,
+                              medium: false,
+                              event_logging: false,
+                              low: false,
+                              normal: true,
+                            },
+                            key_size: 4,
+                            key_pos: 0,
+                            board_instance_mask: 65535
+                          },
+                          tokens: [
+                            {
+                              Bool: {
+                                FchPowerFailEarlyShadow: false
+                              }
+                            },
+                            {
+                              Bool: {
+                                PspTpPort: true
+                              }
+                            },
+                            {
+                              Bool: {
+                                MemSmeMkEnable: false
+                              }
+                            },
+                            {
+                              Bool: {
+                                L3Bist: false
+                              }
+                            },
+                            {
+                              Bool: {
+                                PspEventLogDisplay: true
+                              }
+                            },
+                            {
+                              Bool: {
+                                GnbAdditionalFeatures: true
+                              }
+                            },
+                            {
+                              Bool: {
+                                PspSfsEnable: false
+                              }
+                            },
+                            {
+                              Bool: {
+                                NbioIommu: true
+                              }
+                            },
+                            {
+                              Bool: {
+                                FchSpdControlOwnership: "Linked"
+                              }
+                            },
+                            {
+                              Bool: {
+                                FchSata6Enable: true
+                              }
+                            },
+                            {
+                              Bool: {
+                                PspPsbAutoFuse: true
+                              }
+                            },
+                            {
+                              Bool: {
+                                GnbAdditionalFeatureDsm: false
+                              }
+                            },
+                            {
+                              Bool: {
+                                GnbMpdmaTfEnable: false
+                              }
+                            },
+                            {
+                              Bool: {
+                                FchUsb3Enable: false
+                              }
+                            },
+                            {
+                              Bool: {
+                                MemChannelInterleaving: false
+                              }
+                            },
+                            {
+                              Bool: {
+                                FchSata3Enable: true
+                              }
+                            },
+                            {
+                              Bool: {
+                                MemPstate: false
+                              }
+                            },
+                            {
+                              Bool: {
+                                VgaProgram: true
+                              }
+                            },
+                            {
+                              Bool: {
+                                FchCmosClearEnableMemRestore: false
+                              }
+                            },
+                            {
+                              Bool: {
+                                CcxPpinOptIn: false
+                              }
+                            },
+                            {
+                              Bool: {
+                                MemOcVddioControl: false
+                              }
+                            },
+                            {
+                              Bool: {
+                                MemEnableChipSelectInterleaving: false
+                              }
+                            },
+                            {
+                              Bool: {
+                                ConfigureSecondPcieLink: false
+                              }
+                            },
+                            {
+                              Bool: {
+                                ScanDumpDebugEnable: false
+                              }
+                            },
+                            {
+                              Bool: {
+                                MemMbistAggressorStaticLaneControl: false
+                              }
+                            },
+                            {
+                              Bool: {
+                                FchUsb2Enable: false
+                              }
+                            },
+                            {
+                              Bool: {
+                                FchSata5Enable: true
+                              }
+                            },
+                            {
+                              Bool: {
+                                CmosClearTriggerApcbRecovery: true
+                              }
+                            },
+                            {
+                              Bool: {
+                                FchEspiAblInitEnable: true
+                              }
+                            },
+                            {
+                              Bool: {
+                                FchSata1Enable: true
+                              }
+                            },
+                            {
+                              Bool: {
+                                FcbUsb0Enable: true
+                              }
+                            },
+                            {
+                              Bool: {
+                                FchSata7Enable: true
+                              }
+                            },
+                            {
+                              Bool: {
+                                MemAutoRefreshsCountForThrottling: "Enabled"
+                              }
+                            },
+                            {
+                              Bool: {
+                                FchSataEnable: true
+                              }
+                            },
+                            {
+                              Bool: {
+                                DisplayPmuTrainingResults: false
+                              }
+                            },
+                            {
+                              Bool: {
+                                GnbAdditionalFeatureL3PerformanceBias: true
+                              }
+                            },
+                            {
+                              Bool: {
+                                FchSata2Enable: true
+                              }
+                            },
+                            {
+                              Bool: {
+                                PspSevMode: "Enabled"
+                              }
+                            },
+                            {
+                              Bool: {
+                                PspSfsCosignRequired: false
+                              }
+                            },
+                            {
+                              Bool: {
+                                FchAblApcbBoardIdErrorHalt: true
+                              }
+                            },
+                            {
+                              Bool: {
+                                FchSataMsi: true
+                              }
+                            },
+                            {
+                              Bool: {
+                                MemEnablePowerDown: false
+                              }
+                            },
+                            {
+                              Bool: {
+                                DxioVgaApiEnable: false
+                              }
+                            },
+                            {
+                              Bool: {
+                                FchSata4Enable: true
+                              }
+                            },
+                            {
+                              Bool: {
+                                FchSata0Enable: true
+                              }
+                            },
+                            {
+                              Bool: {
+                                FchUsb1Enable: true
+                              }
+                            },
+                            {
+                              Bool: {
+                                DfCdma: false
+                              }
+                            },
+                            {
+                              Bool: {
+                                PspErrorDisplay: true
+                              }
+                            },
+                            {
+                              Bool: {
+                                MemMbistTgtStaticLaneControl: false
+                              }
+                            },
+                            {
+                              Bool: {
+                                MemDdrRouteBalancedTee: false
+                              }
+                            },
+                            {
+                              Bool: {
+                                PspStopOnError: false
+                              }
+                            },
+                            {
+                              Bool: {
+                                Mcax64BankEnable: false
+                              }
+                            },
+                            {
+                              Bool: {
+                                MemTempControlledRefreshEnable: false
+                              }
+                            },
+                            {
+                              Bool: {
+                                MemTsmeEnable: false
+                              }
+                            },
+                            {
+                              Bool: {
+                                MemTempControlledExtendedRefresh: false
+                              }
+                            },
+                            {
+                              Bool: {
+                                GnbAdditionalFeatureDsmDetector: false
+                              }
+                            },
+                            {
+                              Bool: {
+                                PcieResetControl: true
+                              }
+                            },
+                            {
+                              Bool: {
+                                MemEnableEccFeature: false
+                              }
+                            },
+                            {
+                              Bool: {
+                                BmcInitBeforeDram: false
+                              }
+                            },
+                            {
+                              Bool: {
+                                MemRestoreControl: true
+                              }
+                            }
+                          ]
+                        },
+                        {
+                          header: {
+                            group_id: 12288,
+                            entry_id: 1,
+                            instance_id: 0,
+                            context_type: "Tokens",
+                            context_format: "SortAscending",
+                            unit_size: 8,
+                            priority_mask: {
+                              hard_force: false,
+                              high: false,
+                              medium: false,
+                              event_logging: false,
+                              low: false,
+                              normal: true,
+                            },
+                            key_size: 4,
+                            key_pos: 0,
+                            board_instance_mask: 1
+                          },
+                          tokens: [
+                            {
+                              Byte: {
+                                CcxCcdControl: "Auto"
+                              }
+                            },
+                            {
+                              Byte: {
+                                MemMbistAggressorsChannelDdrMode: "SubChannel"
+                              }
+                            },
+                            {
+                              Byte: {
+                                SecondPcieLinkDevice: 3
+                              }
+                            },
+                            {
+                              Byte: {
+                                FourthPcieLinkSpeed: "Gen2"
+                              }
+                            },
+                            {
+                              Byte: {
+                                DfPdrTuningMode: "Auto"
+                              }
+                            },
+                            {
+                              Byte: {
+                                MemOverrideDimmSpdMaxActivityCount: "Auto"
+                              }
+                            },
+                            {
+                              Byte: {
+                                FourthPcieLinkStartLane: 128
+                              }
+                            },
+                            {
+                              Byte: {
+                                DfGmiEncrypt: "Auto"
+                              }
+                            },
+                            {
+                              Byte: {
+                                FourthPcieLinkFunction: 2
+                              }
+                            },
+                            {
+                              Byte: {
+                                MemMbistPatternLengthDdr: 8
+                              }
+                            },
+                            {
+                              Byte: {
+                                SecondPcieLinkFunction: 5
+                              }
+                            },
+                            {
+                              Byte: {
+                                MemUrgRefLimit: 4
+                              }
+                            },
+                            {
+                              Byte: {
+                                BmcEndLane: 134
+                              }
+                            },
+                            {
+                              Byte: {
+                                MemAutoRefreshFineGranMode: "Fixed1Times"
+                              }
+                            },
+                            {
+                              Byte: {
+                                BmcFunction: 4
+                              }
+                            },
+                            {
+                              Byte: {
+                                FchIc3TransferSpeed: "Sdr2"
+                              }
+                            },
+                            {
+                              Byte: {
+                                ThirdPcieLinkFunction: 1
+                              }
+                            },
+                            {
+                              Byte: {
+                                FchI2cI3cSmbusSelect4: "I2c"
+                              }
+                            },
+                            {
+                              Byte: {
+                                DfXgmiPresetControlMode: "Auto"
+                              }
+                            },
+                            {
+                              Byte: {
+                                WorkloadProfile: "Disabled"
+                              }
+                            },
+                            {
+                              Byte: {
+                                MemMbistWorseCasGranularity: 0
+                              }
+                            },
+                            {
+                              Byte: {
+                                FchSmbusSpeed: {
+                                  Value: 42
+                                }
+                              }
+                            },
+                            {
+                              Byte: {
+                                FchPowerFailMode: "DefaultOff"
+                              }
+                            },
+                            {
+                              Byte: {
+                                MemNvdimmPowerSource: "DeviceManaged"
+                              }
+                            },
+                            {
+                              Byte: {
+                                MemMaxReadCrcErrorReplay: 8
+                              }
+                            },
+                            {
+                              Byte: {
+                                DfDramNumaPerSocket: "Auto"
+                              }
+                            },
+                            {
+                              Byte: {
+                                MemMaxUeccErrorReplay: 8
+                              }
+                            },
+                            {
+                              Byte: {
+                                FchI2cI3cSmbusSelect1: "I2c"
+                              }
+                            },
+                            {
+                              Byte: {
+                                MemMbistReadDataEyeVoltageStep: 1
+                              }
+                            },
+                            {
+                              Byte: {
+                                DfRemapAt1TiB: "Enabled"
+                              }
+                            },
+                            {
+                              Byte: {
+                                FourthPcieLinkDevice: 3
+                              }
+                            },
+                            {
+                              Byte: {
+                                MemMbistPerBitSlaveDieReportDdr: "Auto"
+                              }
+                            },
+                            {
+                              Byte: {
+                                SecondPcieLinkEndLane: 135
+                              }
+                            },
+                            {
+                              Byte: {
+                                Df4LinkMaxXgmiSpeed: "Auto"
+                              }
+                            },
+                            {
+                              Byte: {
+                                FchI2c5SdaRxHold: 0
+                              }
+                            },
+                            {
+                              Byte: {
+                                MemMbistAggressorStaticLaneVal: 0
+                              }
+                            },
+                            {
+                              Byte: {
+                                MemDramDoubleRefreshRate: 0
+                              }
+                            },
+                            {
+                              Byte: {
+                                FourthPcieLinkPortPresent: 0
+                              }
+                            },
+                            {
+                              Byte: {
+                                MemDataPoison: "Enabled"
+                              }
+                            },
+                            {
+                              Byte: {
+                                MemMbistTgtStaticLaneVal: 0
+                              }
+                            },
+                            {
+                              Byte: {
+                                MemMbistDataEyeType: "1D Timing"
+                              }
+                            },
+                            {
+                              Byte: {
+                                DfXgmiCrcScale: 7
+                              }
+                            },
+                            {
+                              Byte: {
+                                Df3LinkMaxXgmiSpeed: "Auto"
+                              }
+                            },
+                            {
+                              Byte: {
+                                FchI2cSdaHoldOverrideMode2: "IgnoreBoth"
+                              }
+                            },
+                            {
+                              Byte: {
+                                MemSelfHealing: "Disabled"
+                              }
+                            },
+                            {
+                              Byte: {
+                                MemMbistAggressorStaticLaneSelEcc: 0
+                              }
+                            },
+                            {
+                              Byte: {
+                                MemMbistReadDataEyeTimingStep: 1
+                              }
+                            },
+                            {
+                              Byte: {
+                                FchI3c2SdaTxHold: 2
+                              }
+                            },
+                            {
+                              Byte: {
+                                MemMbistPatternSelectDdr: "Auto"
+                              }
+                            },
+                            {
+                              Byte: {
+                                FchI2cI3cSmbusSelect5: "I2c"
+                              }
+                            },
+                            {
+                              Byte: {
+                                DfInvertDramMap: "Auto"
+                              }
+                            },
+                            {
+                              Byte: {
+                                DfProbeFilter: "Auto"
+                              }
+                            },
+                            {
+                              Byte: {
+                                DfXgmiEncrypt: "Auto"
+                              }
+                            },
+                            {
+                              Byte: {
+                                MemPsErrorHandling: 0
+                              }
+                            },
+                            {
+                              Byte: {
+                                CcxL3XiPrefetchReqThrottleEnable: "Auto"
+                              }
+                            },
+                            {
+                              Unknown: {
+                                entry_id: "Byte",
+                                tag: 1917190316,
+                                value: 5
+                              }
+                            },
+                            {
+                              Byte: {
+                                MemMaxWriteCrcErrorReplay: 8
+                              }
+                            },
+                            {
+                              Byte: {
+                                MemWriteCrcEnableDdr: 0
+                              }
+                            },
+                            {
+                              Byte: {
+                                MemCpuVrefRange: 0
+                              }
+                            },
+                            {
+                              Byte: {
+                                ThirdPcieLinkSpeed: "Gen3"
+                              }
+                            },
+                            {
+                              Byte: {
+                                DfSaveRestoreMemEncrypt: "Auto"
+                              }
+                            },
+                            {
+                              Byte: {
+                                MemMbistDdrMode: "Disabled"
+                              }
+                            },
+                            {
+                              Byte: {
+                                FchI2cI3cSmbusSelect0: "I2c"
+                              }
+                            },
+                            {
+                              Byte: {
+                                CcxCoreControl: "Auto"
+                              }
+                            },
+                            {
+                              Byte: {
+                                MemReadCrcEnableDdr: 0
+                              }
+                            },
+                            {
+                              Byte: {
+                                FchI2cI3cController3Mode: "I3c"
+                              }
+                            },
+                            {
+                              Byte: {
+                                BmcSocket: 0
+                              }
+                            },
+                            {
+                              Byte: {
+                                SecondPcieLinkSpeed: "Gen2"
+                              }
+                            },
+                            {
+                              Byte: {
+                                MemSpdVerifyCrc: "Verify"
+                              }
+                            },
+                            {
+                              Byte: {
+                                PcieResetPinSelect: 2
+                              }
+                            },
+                            {
+                              Byte: {
+                                FchI2cI3cSmbusSelect2: "I2c"
+                              }
+                            },
+                            {
+                              Byte: {
+                                DfUmcCxlMixedInterleavedMode: "Disabled"
+                              }
+                            },
+                            {
+                              Byte: {
+                                MemMbistDataEyeExecutionRepeatCount: 1
+                              }
+                            },
+                            {
+                              Byte: {
+                                ThirdPcieLinkStartLane: 133
+                              }
+                            },
+                            {
+                              Byte: {
+                                ThirdPcieLinkEndLane: 133
+                              }
+                            },
+                            {
+                              Byte: {
+                                DfBottomIo: 176
+                              }
+                            },
+                            {
+                              Byte: {
+                                CxlResetPin: "Gpio266"
+                              }
+                            },
+                            {
+                              Byte: {
+                                FchConsoleOutSerialPortIoBase: "3f8"
+                              }
+                            },
+                            {
+                              Byte: {
+                                MemMbistTestModeDdr: "Both"
+                              }
+                            },
+                            {
+                              Byte: {
+                                MemMaxRcdParityErrorRelay: 8
+                              }
+                            },
+                            {
+                              Byte: {
+                                SecondPcieLinkPortPresent: 0
+                              }
+                            },
+                            {
+                              Byte: {
+                                MemDataScramble: 1
+                              }
+                            },
+                            {
+                              Byte: {
+                                MemHealingBistRepairTypeDdr: "Soft"
+                              }
+                            },
+                            {
+                              Byte: {
+                                BmcLinkSpeed: "Auto"
+                              }
+                            },
+                            {
+                              Byte: {
+                                FchI2cI3cController2Mode: "I3c"
+                              }
+                            },
+                            {
+                              Byte: {
+                                FchConsoleOutBasicEnable: 0
+                              }
+                            },
+                            {
+                              Byte: {
+                                DfTgtReqGo: "Auto"
+                              }
+                            },
+                            {
+                              Byte: {
+                                MemMbistTgtStaticLaneSelEcc: 0
+                              }
+                            },
+                            {
+                              Byte: {
+                                FchI2c0SdaRxHold: 0
+                              }
+                            },
+                            {
+                              Byte: {
+                                DfXgmiAcDcCoupledLink: {
+                                  socket_0_link_0: "DcCoupled",
+                                  socket_0_link_1: "DcCoupled",
+                                  socket_0_link_2: "DcCoupled",
+                                  socket_0_link_3: "DcCoupled",
+                                  socket_1_link_0: "DcCoupled",
+                                  socket_1_link_1: "DcCoupled",
+                                  socket_1_link_2: "DcCoupled",
+                                  socket_1_link_3: "DcCoupled"
+                                }
+                              }
+                            },
+                            {
+                              Byte: {
+                                FourthPcieLinkEndLane: 131
+                              }
+                            },
+                            {
+                              Byte: {
+                                MemDramVrefRange: 0
+                              }
+                            },
+                            {
+                              Byte: {
+                                MemHealMaxBankFailsDdr: 3
+                              }
+                            },
+                            {
+                              Byte: {
+                                AblSerialBaudRate: "115200 Baud"
+                              }
+                            },
+                            {
+                              Byte: {
+                                BmcRcbCheckingMode: "Auto"
+                              }
+                            },
+                            {
+                              Byte: {
+                                MemTrainingHdtControl: "StageCompletionMessages"
+                              }
+                            },
+                            {
+                              Byte: {
+                                ReservedDramModuleDrtmMode: "Disabled"
+                              }
+                            },
+                            {
+                              Byte: {
+                                CcxSmtControl: "Auto"
+                              }
+                            },
+                            {
+                              Byte: {
+                                DfXgmiConfig: "Auto"
+                              }
+                            },
+                            {
+                              Byte: {
+                                SecondPcieLinkStartLane: 135
+                              }
+                            },
+                            {
+                              Byte: {
+                                MemMbistHaltOnError: 1
+                              }
+                            },
+                            {
+                              Byte: {
+                                FchI3cSdaHoldOverrideMode: "Disabled"
+                              }
+                            },
+                            {
+                              Byte: {
+                                MemMbistAggressorsDdr: "Disabled"
+                              }
+                            },
+                            {
+                              Byte: {
+                                FchI2cI3cController0Mode: "I3c"
+                              }
+                            },
+                            {
+                              Byte: {
+                                PspApmlSbtsiSlaveMode: "I3c"
+                              }
+                            },
+                            {
+                              Byte: {
+                                BmcStartLane: 134
+                              }
+                            },
+                            {
+                              Byte: {
+                                MemSelfRefreshExitStaggering: "Disabled"
+                              }
+                            },
+                            {
+                              Byte: {
+                                FchI3c1SdaTxHold: 2
+                              }
+                            },
+                            {
+                              Byte: {
+                                DfXgmiCrcThreshold: 25
+                              }
+                            },
+                            {
+                              Byte: {
+                                MemRcdParityMode: "Enabled"
+                              }
+                            },
+                            {
+                              Byte: {
+                                FchI2c2SdaRxHold: 0
+                              }
+                            },
+                            {
+                              Byte: {
+                                MemPmuBistAlgorithmSelectDdr: "Vendor"
+                              }
+                            },
+                            {
+                              Byte: {
+                                MemActionOnBistFailure: "DoNothing"
+                              }
+                            },
+                            {
+                              Byte: {
+                                MemMbistWriteDataEyeVoltageStep: 1
+                              }
+                            },
+                            {
+                              Byte: {
+                                DfMemInterleaving: "Auto"
+                              }
+                            },
+                            {
+                              Byte: {
+                                PspEnableDebugMode: "Disabled"
+                              }
+                            },
+                            {
+                              Byte: {
+                                MemRdimmTimingRcdF0Rc0FAdditionalLatency: "Auto"
+                              }
+                            },
+                            {
+                              Byte: {
+                                Df2LinkMaxXgmiSpeed: "Auto"
+                              }
+                            },
+                            {
+                              Byte: {
+                                DfCcdBwThrottleLevel: "Auto"
+                              }
+                            },
+                            {
+                              Byte: {
+                                FchI2cI3cController1Mode: "I3c"
+                              }
+                            },
+                            {
+                              Byte: {
+                                BmcDevice: 3
+                              }
+                            },
+                            {
+                              Byte: {
+                                FchI2cI3cController4Mode: "I3c"
+                              }
+                            },
+                            {
+                              Byte: {
+                                FchI3c3SdaTxHold: 2
+                              }
+                            },
+                            {
+                              Byte: {
+                                MemMbistWriteDataEyeTimingStep: 1
+                              }
+                            },
+                            {
+                              Byte: {
+                                ThirdPcieLinkDevice: 3
+                              }
+                            },
+                            {
+                              Byte: {
+                                FchConsoleOutSerialPortEspiController: {
+                                  espi_controller: "Controller0",
+                                  io_2e_2f_disabled: true,
+                                  io_4e_4f_disabled: true,
+                                }
+                              }
+                            },
+                            {
+                              Byte: {
+                                FchI2c4SdaRxHold: 0
+                              }
+                            },
+                            {
+                              Byte: {
+                                SwCmdThrotCycles: 0
+                              }
+                            },
+                            {
+                              Byte: {
+                                FchConsoleOutMode: "Enabled"
+                              }
+                            },
+                            {
+                              Byte: {
+                                SecondPcieLinkMaxPayload: "HardwareDefault"
+                              }
+                            },
+                            {
+                              Byte: {
+                                FchIc3PushPullHighCount: 8
+                              }
+                            },
+                            {
+                              Byte: {
+                                MemBootTimePostPackageRepair: "Disabled"
+                              }
+                            },
+                            {
+                              Byte: {
+                                MemSubUrgRefLowerBound: 1
+                              }
+                            },
+                            {
+                              Byte: {
+                                NbioSataMode: 2
+                              }
+                            },
+                            {
+                              Byte: {
+                                FchI2cI3cController5Mode: "I3c"
+                              }
+                            },
+                            {
+                              Byte: {
+                                ThirdPcieLinkPortPresent: 0
+                              }
+                            },
+                            {
+                              Byte: {
+                                FchI2cI3cSmbusSelect3: "I2c"
+                              }
+                            },
+                            {
+                              Byte: {
+                                DfPfOrganization: "Auto"
+                              }
+                            },
+                            {
+                              Byte: {
+                                FchI2c1SdaRxHold: 0
+                              }
+                            },
+                            {
+                              Byte: {
+                                CcxApicMode: "Auto"
+                              }
+                            },
+                            {
+                              Byte: {
+                                FchI3c0SdaTxHold: 2
+                              }
+                            },
+                            {
+                              Byte: {
+                                FchI2c3SdaRxHold: 0
+                              }
+                            },
+                            {
+                              Byte: {
+                                FchConsoleOutSerialPort: "Uart0Mmio"
+                              }
+                            }
+                          ]
+                        },
+                        {
+                          header: {
+                            group_id: 12288,
+                            entry_id: 1,
+                            instance_id: 0,
+                            context_type: "Tokens",
+                            context_format: "SortAscending",
+                            unit_size: 8,
+                            priority_mask: {
+                              hard_force: false,
+                              high: false,
+                              medium: false,
+                              event_logging: false,
+                              low: false,
+                              normal: true,
+                            },
+                            key_size: 4,
+                            key_pos: 0,
+                            board_instance_mask: 65535
+                          },
+                          tokens: [
+                            {
+                              Unknown: {
+                                entry_id: "Byte",
+                                tag: 21073919,
+                                value: 40
+                              }
+                            },
+                            {
+                              Byte: {
+                                CcxCcdControl: "Auto"
+                              }
+                            },
+                            {
+                              Byte: {
+                                MemMbistAggressorsChannelDdrMode: "SubChannel"
+                              }
+                            },
+                            {
+                              Byte: {
+                                SecondPcieLinkDevice: 3
+                              }
+                            },
+                            {
+                              Byte: {
+                                FourthPcieLinkSpeed: "Gen2"
+                              }
+                            },
+                            {
+                              Byte: {
+                                DfPdrTuningMode: "Auto"
+                              }
+                            },
+                            {
+                              Unknown: {
+                                entry_id: "Byte",
+                                tag: 105218579,
+                                value: 10
+                              }
+                            },
+                            {
+                              Byte: {
+                                MemOverrideDimmSpdMaxActivityCount: "Auto"
+                              }
+                            },
+                            {
+                              Byte: {
+                                FourthPcieLinkStartLane: 255
+                              }
+                            },
+                            {
+                              Byte: {
+                                DfGmiEncrypt: "Auto"
+                              }
+                            },
+                            {
+                              Byte: {
+                                FourthPcieLinkFunction: 2
+                              }
+                            },
+                            {
+                              Byte: {
+                                MemForcePowerDownThrottleEnableTurin: "Disabled"
+                              }
+                            },
+                            {
+                              Byte: {
+                                MemMbistPatternLengthDdr: 8
+                              }
+                            },
+                            {
+                              Byte: {
+                                SecondPcieLinkFunction: 4
+                              }
+                            },
+                            {
+                              Byte: {
+                                MemUrgRefLimit: 4
+                              }
+                            },
+                            {
+                              Byte: {
+                                BmcEndLane: 134
+                              }
+                            },
+                            {
+                              Unknown: {
+                                entry_id: "Byte",
+                                tag: 340344139,
+                                value: 85
+                              }
+                            },
+                            {
+                              Byte: {
+                                MemAutoRefreshFineGranMode: "Fixed1Times"
+                              }
+                            },
+                            {
+                              Byte: {
+                                BmcFunction: 3
+                              }
+                            },
+                            {
+                              Byte: {
+                                FchIc3TransferSpeed: "Sdr2"
+                              }
+                            },
+                            {
+                              Byte: {
+                                ThirdPcieLinkFunction: 1
+                              }
+                            },
+                            {
+                              Byte: {
+                                FchI2cI3cSmbusSelect4: "I2c"
+                              }
+                            },
+                            {
+                              Byte: {
+                                DfXgmiPresetControlMode: "Auto"
+                              }
+                            },
+                            {
+                              Unknown: {
+                                entry_id: "Byte",
+                                tag: 570755303,
+                                value: 5
+                              }
+                            },
+                            {
+                              Byte: {
+                                WorkloadProfile: "Disabled"
+                              }
+                            },
+                            {
+                              Byte: {
+                                MemMbistWorseCasGranularity: 0
+                              }
+                            },
+                            {
+                              Byte: {
+                                FchSmbusSpeed: {
+                                  Value: 42
+                                }
+                              }
+                            },
+                            {
+                              Byte: {
+                                FchPowerFailMode: "DefaultOff"
+                              }
+                            },
+                            {
+                              Byte: {
+                                MemNvdimmPowerSource: "DeviceManaged"
+                              }
+                            },
+                            {
+                              Byte: {
+                                MemMaxReadCrcErrorReplay: 8
+                              }
+                            },
+                            {
+                              Byte: {
+                                DfDramNumaPerSocket: "Auto"
+                              }
+                            },
+                            {
+                              Byte: {
+                                MemMaxUeccErrorReplay: 8
+                              }
+                            },
+                            {
+                              Byte: {
+                                FchI2cI3cSmbusSelect1: "I2c"
+                              }
+                            },
+                            {
+                              Byte: {
+                                MemMbistReadDataEyeVoltageStep: 1
+                              }
+                            },
+                            {
+                              Byte: {
+                                DfRemapAt1TiB: "Enabled"
+                              }
+                            },
+                            {
+                              Byte: {
+                                FourthPcieLinkDevice: 3
+                              }
+                            },
+                            {
+                              Byte: {
+                                MemMbistPerBitSlaveDieReportDdr: "Auto"
+                              }
+                            },
+                            {
+                              Byte: {
+                                SecondPcieLinkEndLane: 135
+                              }
+                            },
+                            {
+                              Byte: {
+                                Df4LinkMaxXgmiSpeed: "Auto"
+                              }
+                            },
+                            {
+                              Byte: {
+                                FchI2c5SdaRxHold: 0
+                              }
+                            },
+                            {
+                              Byte: {
+                                MemMbistAggressorStaticLaneVal: 0
+                              }
+                            },
+                            {
+                              Byte: {
+                                MemDramDoubleRefreshRate: 0
+                              }
+                            },
+                            {
+                              Byte: {
+                                FourthPcieLinkPortPresent: 0
+                              }
+                            },
+                            {
+                              Byte: {
+                                MemDataPoison: "Enabled"
+                              }
+                            },
+                            {
+                              Byte: {
+                                MemMbistTgtStaticLaneVal: 0
+                              }
+                            },
+                            {
+                              Byte: {
+                                MemMbistDataEyeType: "1D Timing"
+                              }
+                            },
+                            {
+                              Byte: {
+                                DfXgmiCrcScale: 7
+                              }
+                            },
+                            {
+                              Byte: {
+                                Df3LinkMaxXgmiSpeed: "Auto"
+                              }
+                            },
+                            {
+                              Byte: {
+                                FchI2cSdaHoldOverrideMode2: "IgnoreBoth"
+                              }
+                            },
+                            {
+                              Byte: {
+                                MemSelfHealing: "Disabled"
+                              }
+                            },
+                            {
+                              Byte: {
+                                MemMbistAggressorStaticLaneSelEcc: 0
+                              }
+                            },
+                            {
+                              Byte: {
+                                MemMbistReadDataEyeTimingStep: 1
+                              }
+                            },
+                            {
+                              Byte: {
+                                FchI3c2SdaTxHold: 2
+                              }
+                            },
+                            {
+                              Byte: {
+                                MemMbistPatternSelectDdr: "Auto"
+                              }
+                            },
+                            {
+                              Byte: {
+                                FchI2cI3cSmbusSelect5: "I2c"
+                              }
+                            },
+                            {
+                              Byte: {
+                                DfInvertDramMap: "Auto"
+                              }
+                            },
+                            {
+                              Byte: {
+                                DfProbeFilter: "Auto"
+                              }
+                            },
+                            {
+                              Byte: {
+                                DfXgmiEncrypt: "Auto"
+                              }
+                            },
+                            {
+                              Byte: {
+                                MemPsErrorHandling: 0
+                              }
+                            },
+                            {
+                              Byte: {
+                                CcxL3XiPrefetchReqThrottleEnable: "Auto"
+                              }
+                            },
+                            {
+                              Unknown: {
+                                entry_id: "Byte",
+                                tag: 1917190316,
+                                value: 5
+                              }
+                            },
+                            {
+                              Byte: {
+                                MemMaxWriteCrcErrorReplay: 8
+                              }
+                            },
+                            {
+                              Byte: {
+                                MemWriteCrcEnableDdr: 0
+                              }
+                            },
+                            {
+                              Byte: {
+                                MemCpuVrefRange: 0
+                              }
+                            },
+                            {
+                              Byte: {
+                                ThirdPcieLinkSpeed: "Gen3"
+                              }
+                            },
+                            {
+                              Byte: {
+                                DfSaveRestoreMemEncrypt: "Auto"
+                              }
+                            },
+                            {
+                              Byte: {
+                                MemMbistDdrMode: "Disabled"
+                              }
+                            },
+                            {
+                              Byte: {
+                                FchI2cI3cSmbusSelect0: "I2c"
+                              }
+                            },
+                            {
+                              Byte: {
+                                CcxCoreControl: "Auto"
+                              }
+                            },
+                            {
+                              Byte: {
+                                MemReadCrcEnableDdr: 0
+                              }
+                            },
+                            {
+                              Byte: {
+                                FchI2cI3cController3Mode: "I3c"
+                              }
+                            },
+                            {
+                              Byte: {
+                                BmcSocket: 0
+                              }
+                            },
+                            {
+                              Byte: {
+                                SecondPcieLinkSpeed: "Gen2"
+                              }
+                            },
+                            {
+                              Byte: {
+                                MemSpdVerifyCrc: "Verify"
+                              }
+                            },
+                            {
+                              Byte: {
+                                PcieResetPinSelect: 2
+                              }
+                            },
+                            {
+                              Byte: {
+                                FchI2cI3cSmbusSelect2: "I2c"
+                              }
+                            },
+                            {
+                              Byte: {
+                                DfUmcCxlMixedInterleavedMode: "Disabled"
+                              }
+                            },
+                            {
+                              Byte: {
+                                MemMbistDataEyeExecutionRepeatCount: 1
+                              }
+                            },
+                            {
+                              Byte: {
+                                ThirdPcieLinkStartLane: 128
+                              }
+                            },
+                            {
+                              Byte: {
+                                ThirdPcieLinkEndLane: 131
+                              }
+                            },
+                            {
+                              Byte: {
+                                DfBottomIo: 176
+                              }
+                            },
+                            {
+                              Byte: {
+                                CxlResetPin: "Gpio26"
+                              }
+                            },
+                            {
+                              Byte: {
+                                FchConsoleOutSerialPortIoBase: "3f8"
+                              }
+                            },
+                            {
+                              Byte: {
+                                MemMbistTestModeDdr: "Both"
+                              }
+                            },
+                            {
+                              Byte: {
+                                MemMaxRcdParityErrorRelay: 8
+                              }
+                            },
+                            {
+                              Byte: {
+                                SecondPcieLinkPortPresent: 0
+                              }
+                            },
+                            {
+                              Byte: {
+                                MemDataScramble: 1
+                              }
+                            },
+                            {
+                              Byte: {
+                                MemHealingBistRepairTypeDdr: "Soft"
+                              }
+                            },
+                            {
+                              Byte: {
+                                BmcLinkSpeed: "Auto"
+                              }
+                            },
+                            {
+                              Byte: {
+                                FchI2cI3cController2Mode: "I3c"
+                              }
+                            },
+                            {
+                              Byte: {
+                                FchConsoleOutBasicEnable: 0
+                              }
+                            },
+                            {
+                              Byte: {
+                                DfTgtReqGo: "Auto"
+                              }
+                            },
+                            {
+                              Byte: {
+                                MemMbistTgtStaticLaneSelEcc: 0
+                              }
+                            },
+                            {
+                              Byte: {
+                                FchI2c0SdaRxHold: 0
+                              }
+                            },
+                            {
+                              Byte: {
+                                DfXgmiAcDcCoupledLink: {
+                                  socket_0_link_0: "DcCoupled",
+                                  socket_0_link_1: "DcCoupled",
+                                  socket_0_link_2: "DcCoupled",
+                                  socket_0_link_3: "DcCoupled",
+                                  socket_1_link_0: "DcCoupled",
+                                  socket_1_link_1: "DcCoupled",
+                                  socket_1_link_2: "DcCoupled",
+                                  socket_1_link_3: "DcCoupled"
+                                }
+                              }
+                            },
+                            {
+                              Byte: {
+                                FourthPcieLinkEndLane: 255
+                              }
+                            },
+                            {
+                              Byte: {
+                                MemDramVrefRange: 0
+                              }
+                            },
+                            {
+                              Byte: {
+                                MemHealMaxBankFailsDdr: 3
+                              }
+                            },
+                            {
+                              Byte: {
+                                AblSerialBaudRate: "115200 Baud"
+                              }
+                            },
+                            {
+                              Byte: {
+                                BmcRcbCheckingMode: "Auto"
+                              }
+                            },
+                            {
+                              Byte: {
+                                MemOdtsMode: "Enabled"
+                              }
+                            },
+                            {
+                              Byte: {
+                                MemTrainingHdtControl: "StageCompletionMessages"
+                              }
+                            },
+                            {
+                              Byte: {
+                                ReservedDramModuleDrtmMode: "Disabled"
+                              }
+                            },
+                            {
+                              Byte: {
+                                CcxSmtControl: "Auto"
+                              }
+                            },
+                            {
+                              Byte: {
+                                DfXgmiConfig: "Auto"
+                              }
+                            },
+                            {
+                              Byte: {
+                                SecondPcieLinkStartLane: 135
+                              }
+                            },
+                            {
+                              Byte: {
+                                MemMbistHaltOnError: 1
+                              }
+                            },
+                            {
+                              Byte: {
+                                FchI3cSdaHoldOverrideMode: "Disabled"
+                              }
+                            },
+                            {
+                              Byte: {
+                                MemMbistAggressorsDdr: "Disabled"
+                              }
+                            },
+                            {
+                              Byte: {
+                                FchI2cI3cController0Mode: "I3c"
+                              }
+                            },
+                            {
+                              Byte: {
+                                PspApmlSbtsiSlaveMode: "I3c"
+                              }
+                            },
+                            {
+                              Byte: {
+                                BmcStartLane: 134
+                              }
+                            },
+                            {
+                              Byte: {
+                                MemSelfRefreshExitStaggering: "Disabled"
+                              }
+                            },
+                            {
+                              Unknown: {
+                                entry_id: "Byte",
+                                tag: 3169386577,
+                                value: 0
+                              }
+                            },
+                            {
+                              Byte: {
+                                FchI3c1SdaTxHold: 2
+                              }
+                            },
+                            {
+                              Byte: {
+                                DfXgmiCrcThreshold: 25
+                              }
+                            },
+                            {
+                              Byte: {
+                                MemRcdParityMode: "Enabled"
+                              }
+                            },
+                            {
+                              Byte: {
+                                FchI2c2SdaRxHold: 0
+                              }
+                            },
+                            {
+                              Byte: {
+                                MemPmuBistAlgorithmSelectDdr: "Vendor"
+                              }
+                            },
+                            {
+                              Byte: {
+                                MemActionOnBistFailure: "DoNothing"
+                              }
+                            },
+                            {
+                              Byte: {
+                                MemMbistWriteDataEyeVoltageStep: 1
+                              }
+                            },
+                            {
+                              Byte: {
+                                DfMemInterleaving: "Auto"
+                              }
+                            },
+                            {
+                              Byte: {
+                                PspEnableDebugMode: "Disabled"
+                              }
+                            },
+                            {
+                              Byte: {
+                                MemRdimmTimingRcdF0Rc0FAdditionalLatency: "Auto"
+                              }
+                            },
+                            {
+                              Byte: {
+                                Df2LinkMaxXgmiSpeed: "Auto"
+                              }
+                            },
+                            {
+                              Byte: {
+                                DfCcdBwThrottleLevel: "Auto"
+                              }
+                            },
+                            {
+                              Byte: {
+                                FchI2cI3cController1Mode: "I3c"
+                              }
+                            },
+                            {
+                              Byte: {
+                                BmcDevice: 3
+                              }
+                            },
+                            {
+                              Byte: {
+                                FchI2cI3cController4Mode: "I3c"
+                              }
+                            },
+                            {
+                              Byte: {
+                                FchI3c3SdaTxHold: 2
+                              }
+                            },
+                            {
+                              Byte: {
+                                MemMbistWriteDataEyeTimingStep: 1
+                              }
+                            },
+                            {
+                              Byte: {
+                                ThirdPcieLinkDevice: 3
+                              }
+                            },
+                            {
+                              Byte: {
+                                FchConsoleOutSerialPortEspiController: {
+                                  espi_controller: "Controller0",
+                                  io_2e_2f_disabled: true,
+                                  io_4e_4f_disabled: true,
+                                }
+                              }
+                            },
+                            {
+                              Byte: {
+                                FchI2c4SdaRxHold: 0
+                              }
+                            },
+                            {
+                              Byte: {
+                                SwCmdThrotCycles: 0
+                              }
+                            },
+                            {
+                              Byte: {
+                                FchConsoleOutMode: "Enabled"
+                              }
+                            },
+                            {
+                              Byte: {
+                                SecondPcieLinkMaxPayload: "HardwareDefault"
+                              }
+                            },
+                            {
+                              Byte: {
+                                FchIc3PushPullHighCount: 8
+                              }
+                            },
+                            {
+                              Byte: {
+                                MemBootTimePostPackageRepair: "Disabled"
+                              }
+                            },
+                            {
+                              Byte: {
+                                MemSubUrgRefLowerBound: 1
+                              }
+                            },
+                            {
+                              Byte: {
+                                NbioSataMode: 2
+                              }
+                            },
+                            {
+                              Byte: {
+                                FchI2cI3cController5Mode: "I3c"
+                              }
+                            },
+                            {
+                              Byte: {
+                                ThirdPcieLinkPortPresent: 0
+                              }
+                            },
+                            {
+                              Unknown: {
+                                entry_id: "Byte",
+                                tag: 3965370643,
+                                value: 20
+                              }
+                            },
+                            {
+                              Byte: {
+                                FchI2cI3cSmbusSelect3: "I2c"
+                              }
+                            },
+                            {
+                              Byte: {
+                                DfPfOrganization: "Auto"
+                              }
+                            },
+                            {
+                              Byte: {
+                                FchI2c1SdaRxHold: 0
+                              }
+                            },
+                            {
+                              Byte: {
+                                CcxApicMode: "Auto"
+                              }
+                            },
+                            {
+                              Byte: {
+                                FchI3c0SdaTxHold: 2
+                              }
+                            },
+                            {
+                              Byte: {
+                                FchI2c3SdaRxHold: 0
+                              }
+                            },
+                            {
+                              Byte: {
+                                FchConsoleOutSerialPort: "Uart0Mmio"
+                              }
+                            }
+                          ]
+                        },
+                        {
+                          header: {
+                            group_id: 12288,
+                            entry_id: 2,
+                            instance_id: 0,
+                            context_type: "Tokens",
+                            context_format: "SortAscending",
+                            unit_size: 8,
+                            priority_mask: {
+                              hard_force: false,
+                              high: false,
+                              medium: false,
+                              event_logging: false,
+                              low: false,
+                              normal: true,
+                            },
+                            key_size: 4,
+                            key_pos: 0,
+                            board_instance_mask: 65535
+                          },
+                          tokens: [
+                            {
+                              Word: {
+                                DfXgmiInitPresetS1L2: 17476
+                              }
+                            },
+                            {
+                              Word: {
+                                FchSataSvid: 65535
+                              }
+                            },
+                            {
+                              Word: {
+                                FchI2c1SdaTxHold: 53
+                              }
+                            },
+                            {
+                              Word: {
+                                FchConsoleOutSerialPortCustomIoBase: 0
+                              }
+                            },
+                            {
+                              Word: {
+                                DfXgmiInitPresetS0L2: 17476
+                              }
+                            },
+                            {
+                              Word: {
+                                EccSymbolSize: "x16"
+                              }
+                            },
+                            {
+                              Word: {
+                                DfBelow4GbAreaSize: 256
+                              }
+                            },
+                            {
+                              Word: {
+                                DfXgmiInitPresetS1L3: 17476
+                              }
+                            },
+                            {
+                              Word: {
+                                MemRollWindowDepth2: {
+                                  Memclks: 1023
+                                }
+                              }
+                            },
+                            {
+                              Word: {
+                                OdtsCmdThrottleCycles2: 511
+                              }
+                            },
+                            {
+                              Word: {
+                                DfXgmiInitPresetS0L1: 17476
+                              }
+                            },
+                            {
+                              Word: {
+                                FchUsbSsid: 65535
+                              }
+                            },
+                            {
+                              Word: {
+                                FchUsbSvid: 65535
+                              }
+                            },
+                            {
+                              Word: {
+                                DfXgmiInitPresetS1L1: 17476
+                              }
+                            },
+                            {
+                              Word: {
+                                FchI2c2SdaTxHold: 53
+                              }
+                            },
+                            {
+                              Word: {
+                                FchSataSsid: 65535
+                              }
+                            },
+                            {
+                              Word: {
+                                DfXgmiInitPresetS0L3: 17476
+                              }
+                            },
+                            {
+                              Word: {
+                                FchGppClkMap: "Auto"
+                              }
+                            },
+                            {
+                              Word: {
+                                FchI2c3SdaTxHold: 53
+                              }
+                            },
+                            {
+                              Word: {
+                                DfXgmiInitPresetS1L0: 17476
+                              }
+                            },
+                            {
+                              Word: {
+                                FchI2c4SdaTxHold: 53
+                              }
+                            },
+                            {
+                              Word: {
+                                MemPmuBistAlgorithmSelect: {
+                                  algorithm_1: true,
+                                  algorithm_2: true,
+                                  algorithm_3: true,
+                                  algorithm_4: true,
+                                  algorithm_5: true,
+                                  algorithm_6: true,
+                                  algorithm_7: true,
+                                  algorithm_8: true,
+                                  algorithm_9: true,
+                                }
+                              }
+                            },
+                            {
+                              Word: {
+                                PspSyshubWatchdogTimerInterval: 2600
+                              }
+                            },
+                            {
+                              Word: {
+                                FchI2c5SdaTxHold: 53
+                              }
+                            },
+                            {
+                              Word: {
+                                DfXgmiInitPresetS0L0: 17476
+                              }
+                            },
+                            {
+                              Word: {
+                                FchI2c0SdaTxHold: 53
+                              }
+                            }
+                          ]
+                        },
+                        {
+                          header: {
+                            group_id: 12288,
+                            entry_id: 4,
+                            instance_id: 0,
+                            context_type: "Tokens",
+                            context_format: "SortAscending",
+                            unit_size: 8,
+                            priority_mask: {
+                              hard_force: false,
+                              high: false,
+                              medium: false,
+                              event_logging: false,
+                              low: false,
+                              normal: true,
+                            },
+                            key_size: 4,
+                            key_pos: 0,
+                            board_instance_mask: 65535
+                          },
+                          tokens: [
+                            {
+                              Dword: {
+                                DfXgmiTxEqS1L1P01: 0
+                              }
+                            },
+                            {
+                              Dword: {
+                                DfXgmiPresetP11: 12288
+                              }
+                            },
+                            {
+                              Dword: {
+                                DfXgmiChannelTypeSelect: {
+                                  s0l0: "Disabled",
+                                  s0l1: "Disabled",
+                                  s0l2: "Disabled",
+                                  s0l3: "Disabled",
+                                  s1l0: "Disabled",
+                                  s1l1: "Disabled",
+                                  s1l2: "Disabled",
+                                  s1l3: "Disabled"
+                                }
+                              }
+                            },
+                            {
+                              Dword: {
+                                DfXgmiTxEqS1L2P23: 0
+                              }
+                            },
+                            {
+                              Dword: {
+                                DfXgmiTxEqS0L2P23: 0
+                              }
+                            },
+                            {
+                              Dword: {
+                                DxioPhyParamDc: "Skip"
+                              }
+                            },
+                            {
+                              Dword: {
+                                MemPowerDownMode: 0
+                              }
+                            },
+                            {
+                              Dword: {
+                                PspOpnPlatformComptFusing: 1
+                              }
+                            },
+                            {
+                              Dword: {
+                                DfXgmiPresetP13: 12288
+                              }
+                            },
+                            {
+                              Dword: {
+                                MemBusFrequencyLimit: "Ddr6400"
+                              }
+                            },
+                            {
+                              Dword: {
+                                DfXgmiTxEqS0L3P23: 0
+                              }
+                            },
+                            {
+                              Dword: {
+                                MemUmaSize: 0
+                              }
+                            },
+                            {
+                              Dword: {
+                                DfPciMmioSize: 268435456
+                              }
+                            },
+                            {
+                              Dword: {
+                                FchRom3BaseHigh: 0
+                              }
+                            },
+                            {
+                              Dword: {
+                                DfXgmiTxEqS1L0P23: 0
+                              }
+                            },
+                            {
+                              Dword: {
+                                DfXgmiPresetP15: 12288
+                              }
+                            },
+                            {
+                              Dword: {
+                                MemUmaAlignment: 16777152
+                              }
+                            },
+                            {
+                              Dword: {
+                                PcieResetGpioPin: 4294967295
+                              }
+                            },
+                            {
+                              Dword: {
+                                DfXgmiPresetP12: 12288
+                              }
+                            },
+                            {
+                              Dword: {
+                                DfXgmiTxEqS0L3P01: 0
+                              }
+                            },
+                            {
+                              Dword: {
+                                DfXgmiTxEqS1L3P01: 0
+                              }
+                            },
+                            {
+                              Dword: {
+                                DfXgmiTxEqS0L1P01: 0
+                              }
+                            },
+                            {
+                              Dword: {
+                                DfXgmiTxEqS1L1P23: 0
+                              }
+                            },
+                            {
+                              Dword: {
+                                MemMbistAggressorStaticLaneSelLo: 0
+                              }
+                            },
+                            {
+                              Dword: {
+                                DfXgmiPresetP14: 12288
+                              }
+                            },
+                            {
+                              Dword: {
+                                DfPciMmioBaseLo: 0
+                              }
+                            },
+                            {
+                              Dword: {
+                                DxioPhyParamIqofc: "Skip"
+                              }
+                            },
+                            {
+                              Dword: {
+                                MemMbistTgtStaticLaneSelLo: 0
+                              }
+                            },
+                            {
+                              Dword: {
+                                DfXgmiTxEqS1L3P23: 0
+                              }
+                            },
+                            {
+                              Dword: {
+                                CcxMinSevAsid: 1
+                              }
+                            },
+                            {
+                              Dword: {
+                                DfXgmiTxEqS0L1P23: 0
+                              }
+                            },
+                            {
+                              Dword: {
+                                MemMbistTgtStaticLaneSelHi: 0
+                              }
+                            },
+                            {
+                              Dword: {
+                                DxioPhyParamPole: "Skip"
+                              }
+                            },
+                            {
+                              Dword: {
+                                MemSelfHealBistTimeout: 10000
+                              }
+                            },
+                            {
+                              Dword: {
+                                DfXgmiTxEqS0L0P23: 0
+                              }
+                            },
+                            {
+                              Dword: {
+                                DfXgmiInitialPreset: 1145324612
+                              }
+                            },
+                            {
+                              Dword: {
+                                DfXgmiTxEqS1L2P01: 0
+                              }
+                            },
+                            {
+                              Dword: {
+                                MemClockValue: "Ddr2400"
+                              }
+                            },
+                            {
+                              Dword: {
+                                DfXgmiTxEqS1L0P01: 0
+                              }
+                            },
+                            {
+                              Dword: {
+                                CpuFetchFromSpiApBase: 4293918720
+                              }
+                            },
+                            {
+                              Dword: {
+                                DfXgmiTxEqS0L2P01: 0
+                              }
+                            },
+                            {
+                              Dword: {
+                                PspMeasureConfig: 0
+                              }
+                            },
+                            {
+                              Dword: {
+                                DxioPhyParamVga: "Skip"
+                              }
+                            },
+                            {
+                              Dword: {
+                                DfXgmiTxEqS0L0P01: 0
+                              }
+                            },
+                            {
+                              Dword: {
+                                DfPciMmioBaseHi: 16379
+                              }
+                            },
+                            {
+                              Dword: {
+                                MemMbistAggressorStaticLaneSelHi: 0
+                              }
+                            },
+                            {
+                              Dword: {
+                                MemUserTimingMode: "Auto"
+                              }
+                            }
+                          ]
+                        }
+                      ]
+                    }
+                  },
+                  target: {
+                    type: "ApcbBackup"
+                  }
+                },
+                {
+                  "source": "Implied",
+                  "target": {
+                    "type": "Apob",
+                    "ram_destination_address": 0x4000000
+                  }
+                },
+                {
+                  "source": "Implied",
+                  target: {
+                    type: "ApobNvCopy",
+                    flash_location: 0x7000000,
+                    size: 0xd0000
+                  }
+                },
+                {
+                  source: {
+                    BlobFile: "Type0x64_AppbDdr5RdimmImem3_BRH.csbin"
+                  },
+                  target: {
+                    type: "PmuFirmwareInstructions",
+                    instance: 3,
+                    sub_program: 0
+                  }
+                },
+                {
+                  source: {
+                    BlobFile: "Type0x64_AppbDdr5RdimmImem3_BRH_C0.csbin"
+                  },
+                  target: {
+                    type: "PmuFirmwareInstructions",
+                    instance: 3,
+                    sub_program: 4,
+                  }
+                },
+                {
+                  source: {
+                    BlobFile: "Type0x64_AppbDdr5RdimmImem4_BRH.csbin"
+                  },
+                  target: {
+                    type: "PmuFirmwareInstructions",
+                    instance: 4,
+                    sub_program: 0,
+                  }
+                },
+                {
+                  source: {
+                    BlobFile: "Type0x64_AppbDdr5RdimmImem4_BRH_C0.csbin"
+                  },
+                  target: {
+                    type: "PmuFirmwareInstructions",
+                    instance: 4,
+                    sub_program: 4,
+                  }
+                },
+                {
+                  source: {
+                    BlobFile: "Type0x64_AppbDdr5RdimmPosttrainImem9_BRH.csbin"
+                  },
+                  target: {
+                    type: "PmuFirmwareInstructions",
+                    instance: 9,
+                    sub_program: 0,
+                  }
+                },
+                {
+                  source: {
+                    BlobFile: "Type0x64_AppbDdr5RdimmPosttrainImem9_BRH_C0.csbin"
+                  },
+                  target: {
+                    type: "PmuFirmwareInstructions",
+                    instance: 9,
+                    sub_program: 4,
+                  }
+                },
+                {
+                  source: {
+                    BlobFile: "Type0x64_AppbDdr5RdimmPosttrainImem10_BRH.csbin"
+                  },
+                  target: {
+                    type: "PmuFirmwareInstructions",
+                    instance: 10,
+                    sub_program: 0,
+                  }
+                },
+                {
+                  source: {
+                    BlobFile: "Type0x64_AppbDdr5RdimmPosttrainImem10_BRH_C0.csbin"
+                  },
+                  target: {
+                    type: "PmuFirmwareInstructions",
+                    instance: 10,
+                    sub_program: 4,
+                  }
+                },
+                {
+                  source: {
+                    BlobFile: "Type0x64_AppbDdr5RdimmQuickbootImem11_BRH_C0.csbin"
+                  },
+                  target: {
+                    type: "PmuFirmwareInstructions",
+                    instance: 11,
+                    sub_program: 4,
+                  }
+                },
+                {
+                  source: {
+                    BlobFile: "Type0x65_AppbDdr5RdimmDmem3_BRH.csbin"
+                  },
+                  target: {
+                    type: "PmuFirmwareData",
+                    instance: 3,
+                    sub_program: 0
+                  }
+                },
+                {
+                  source: {
+                    BlobFile: "Type0x65_AppbDdr5RdimmDmem3_BRH_C0.csbin"
+                  },
+                  target: {
+                    type: "PmuFirmwareData",
+                    instance: 3,
+                    sub_program: 4
+                  }
+                },
+                {
+                  source: {
+                    BlobFile: "Type0x65_AppbDdr5RdimmDmem4_BRH.csbin"
+                  },
+                  target: {
+                    type: "PmuFirmwareData",
+                    instance: 4,
+                    sub_program: 0
+                  }
+                },
+                {
+                  source: {
+                    BlobFile: "Type0x65_AppbDdr5RdimmDmem4_BRH_C0.csbin"
+                  },
+                  target: {
+                    type: "PmuFirmwareData",
+                    instance: 4,
+                    sub_program: 4
+                  }
+                },
+                {
+                  source: {
+                    BlobFile: "Type0x65_AppbDdr5RdimmPosttrainDmem9_BRH.csbin"
+                  },
+                  target: {
+                    type: "PmuFirmwareData",
+                    instance: 9,
+                    sub_program: 0
+                  }
+                },
+                {
+                  source: {
+                    BlobFile: "Type0x65_AppbDdr5RdimmPosttrainDmem9_BRH_C0.csbin"
+                  },
+                  target: {
+                    type: "PmuFirmwareData",
+                    instance: 9,
+                    sub_program: 4
+                  }
+                },
+                {
+                  source: {
+                    BlobFile: "Type0x65_AppbDdr5RdimmPosttrainDmem10_BRH.csbin"
+                  },
+                  target: {
+                    type: "PmuFirmwareData",
+                    instance: 10,
+                    sub_program: 0
+                  }
+                },
+                {
+                  source: {
+                    BlobFile: "Type0x65_AppbDdr5RdimmPosttrainDmem10_BRH_C0.csbin"
+                  },
+                  target: {
+                    type: "PmuFirmwareData",
+                    instance: 10,
+                    sub_program: 4
+                  }
+                },
+                {
+                  source: {
+                    BlobFile: "Type0x65_AppbDdr5RdimmQuickbootDmem11_BRH_C0.csbin"
+                  },
+                  target: {
+                    type: "PmuFirmwareData",
+                    instance: 11,
+                    sub_program: 4
+                  }
+                },
+                {
+                  source: {
+                    BlobFile: "Type0x65_AppbDdr5RdimmQuickbootDmem12_BRH_C0.csbin"
+                  },
+                  target: {
+                    type: "PmuFirmwareData",
+                    instance: 12,
+                    sub_program: 4
+                  }
+                },
+              ]
+            }
+          },
+          target: {
+            type: "SecondLevelDirectory"
+          }
+        },
       ]
     }
   }


### PR DESCRIPTION
In order to support eMCR - https://github.com/oxidecomputer/stlouis/issues/707

The flash address here is a placeholder, but it looks like the right thing was done:

```
atrium:helios:emcr% gmake turin-rubyred-1.0.0.2-p1.img PAYLOAD=../nanobl-rs/obj/nanobl-rs.elf
cargo run -- generate -s '16 MiB'  -v -B . -B amd-firmware/BRH/1.0.0.2-p1 -c etc/turin-rubyred-1.0.0.2-p1.efs.json5 -r ../nanobl-rs/obj/nanobl-rs.elf -o turin-rubyred-1.0.0.2-p1.img
    Finished dev [unoptimized + debuginfo] target(s) in 0.06s
     Running `target/debug/amd-host-image-builder generate -s '16 MiB' -v -B . -B amd-firmware/BRH/1.0.0.2-p1 -c etc/turin-rubyred-1.0.0.2-p1.efs.json5 -r ../nanobl-rs/obj/nanobl-rs.elf -o turin-rubyred-1.0.0.2-p1.img`

atrium:helios:emcr% cargo run dump -i turin-rubyred-1.0.0.2-p1.img | grep -B3 -A13 Apob
    Finished dev [unoptimized + debuginfo] target(s) in 0.06s
     Running `target/debug/amd-host-image-builder dump -i turin-rubyred-1.0.0.2-p1.img`
        {
          source: "Implied",
          target: {
            type: "Apob",
            region_type: "Normal",
            reset_image: false,
            copy_image: false,
            read_only: false,
            compressed: false,
            instance: 0,
            sub_program: 0,
            rom_id: "SpiCs1",
            flash_location: 0,
            size: 0,
            ram_destination_address: 67108864
          }
        },
        {
          source: "Implied",
          target: {
            type: "ApobNvCopy",
            region_type: "Normal",
            reset_image: false,
            copy_image: false,
            read_only: false,
            compressed: false,
            instance: 0,
            sub_program: 0,
            rom_id: "SpiCs1",
            flash_location: 305419896,
            size: 851968,
            ram_destination_address: null
          }
        },
```
