### PR TITLE
toolchain: slim down `rust-toolchain.toml`

### DIFF
--- a/rust-toolchain.toml
+++ b/rust-toolchain.toml
@@ -1,2 +1,2 @@
 [toolchain]
-components = [ "rustfmt", "rust-src", "rust-analyzer" ]
+components = [ "rustfmt", "clippy" ]


### PR DESCRIPTION
Now that we're on stable Rust, we don't need to specify Rust analyzer as a component to be installed (users can do that themselves).  Slim this down to just the bits that we actually use; `rustfmt` and `clippy` seem the most useful.