### PR TITLE
Enable BDAT on Turin configs.

### DIFF
--- a/etc/turin-cosmo-1.0.0.3-p1.efs.json5
+++ b/etc/turin-cosmo-1.0.0.3-p1.efs.json5
@@ -10903,6 +10903,21 @@
                     },
                     {
                       Byte: {
+                        MemMbistDataEyeSilentExecutionDdr: "Disabled"
+                      }
+                    },
+                    {
+                      Byte: {
+                        BdatSupport: "Enabled"
+                      }
+                    },
+                    {
+                      Byte: {
+                        BdatPrintData: "Disabled"
+                      }
+                    },
+                    {
+                      Byte: {
                         FchI2cI3cSmbusSelect0: "I2c"
                       }
                     },

--- a/etc/turin-ruby-0.0.7.3.efs.json5
+++ b/etc/turin-ruby-0.0.7.3.efs.json5
@@ -9054,6 +9054,21 @@
                       }
                     },
                     {
+                      Byte: {
+                        MemMbistDataEyeSilentExecutionDdr: "Disabled"
+                      }
+                    },
+                    {
+                      Byte: {
+                        BdatSupport: "Enabled"
+                      }
+                    },
+                    {
+                      Byte: {
+                        BdatPrintData: "Disabled"
+                      }
+                    },
+                    {
                       "Byte": {
                         "FchI2cI3cSmbusSelect0": "I2c"
                       }
@@ -9817,6 +9832,21 @@
                     {
                       "Byte": {
                         "MemMbistDdrMode": "Disabled"
+                      }
+                    },
+                    {
+                      Byte: {
+                        MemMbistDataEyeSilentExecutionDdr: "Disabled"
+                      }
+                    },
+                    {
+                      Byte: {
+                        BdatSupport: "Enabled"
+                      }
+                    },
+                    {
+                      Byte: {
+                        BdatPrintData: "Disabled"
                       }
                     },
                     {

--- a/etc/turin-ruby-0.0.8.1.efs.json5
+++ b/etc/turin-ruby-0.0.8.1.efs.json5
@@ -9046,6 +9046,21 @@
                       }
                     },
                     {
+                      Byte: {
+                        MemMbistDataEyeSilentExecutionDdr: "Disabled"
+                      }
+                    },
+                    {
+                      Byte: {
+                        BdatSupport: "Enabled"
+                      }
+                    },
+                    {
+                      Byte: {
+                        BdatPrintData: "Disabled"
+                      }
+                    },
+                    {
                       "Byte": {
                         "FchI2cI3cSmbusSelect0": "I2c"
                       }
@@ -9809,6 +9824,21 @@
                     {
                       "Byte": {
                         "MemMbistDdrMode": "Disabled"
+                      }
+                    },
+                    {
+                      Byte: {
+                        MemMbistDataEyeSilentExecutionDdr: "Disabled"
+                      }
+                    },
+                    {
+                      Byte: {
+                        BdatSupport: "Enabled"
+                      }
+                    },
+                    {
+                      Byte: {
+                        BdatPrintData: "Disabled"
                       }
                     },
                     {

--- a/etc/turin-ruby-1.0.0.1-p1.efs.json5
+++ b/etc/turin-ruby-1.0.0.1-p1.efs.json5
@@ -8912,6 +8912,21 @@
                     },
                     {
                       Byte: {
+                        MemMbistDataEyeSilentExecutionDdr: "Disabled"
+                      }
+                    },
+                    {
+                      Byte: {
+                        BdatSupport: "Enabled"
+                      }
+                    },
+                    {
+                      Byte: {
+                        BdatPrintData: "Disabled"
+                      }
+                    },
+                    {
+                      Byte: {
                         FchI2cI3cSmbusSelect0: "I2c"
                       }
                     },
@@ -9675,6 +9690,21 @@
                     {
                       Byte: {
                         MemMbistDdrMode: "Disabled"
+                      }
+                    },
+                    {
+                      Byte: {
+                        MemMbistDataEyeSilentExecutionDdr: "Disabled"
+                      }
+                    },
+                    {
+                      Byte: {
+                        BdatSupport: "Enabled"
+                      }
+                    },
+                    {
+                      Byte: {
+                        BdatPrintData: "Disabled"
                       }
                     },
                     {

--- a/etc/turin-ruby-1.0.0.2-p1.efs.json5
+++ b/etc/turin-ruby-1.0.0.2-p1.efs.json5
@@ -12268,6 +12268,21 @@
                     },
                     {
                       Byte: {
+                        MemMbistDataEyeSilentExecutionDdr: "Disabled"
+                      }
+                    },
+                    {
+                      Byte: {
+                        BdatSupport: "Enabled"
+                      }
+                    },
+                    {
+                      Byte: {
+                        BdatPrintData: "Disabled"
+                      }
+                    },
+                    {
+                      Byte: {
                         FchI2cI3cSmbusSelect0: "I2c"
                       }
                     },
@@ -13042,6 +13057,21 @@
                     {
                       Byte: {
                         MemMbistDdrMode: "Disabled"
+                      }
+                    },
+                    {
+                      Byte: {
+                        MemMbistDataEyeSilentExecutionDdr: "Disabled"
+                      }
+                    },
+                    {
+                      Byte: {
+                        BdatSupport: "Enabled"
+                      }
+                    },
+                    {
+                      Byte: {
+                        BdatPrintData: "Disabled"
                       }
                     },
                     {

--- a/etc/turin-ruby-1.0.0.3-p1.efs.json5
+++ b/etc/turin-ruby-1.0.0.3-p1.efs.json5
@@ -12161,6 +12161,21 @@
                     },
                     {
                       Byte: {
+                        MemMbistDataEyeSilentExecutionDdr: "Disabled"
+                      }
+                    },
+                    {
+                      Byte: {
+                        BdatSupport: "Enabled"
+                      }
+                    },
+                    {
+                      Byte: {
+                        BdatPrintData: "Disabled"
+                      }
+                    },
+                    {
+                      Byte: {
                         FchI2cI3cSmbusSelect0: "I2c"
                       }
                     },
@@ -12900,6 +12915,21 @@
                     {
                       Byte: {
                         MemMbistDdrMode: "Disabled"
+                      }
+                    },
+                    {
+                      Byte: {
+                        MemMbistDataEyeSilentExecutionDdr: "Disabled"
+                      }
+                    },
+                    {
+                      Byte: {
+                        BdatSupport: "Enabled"
+                      }
+                    },
+                    {
+                      Byte: {
+                        BdatPrintData: "Disabled"
                       }
                     },
                     {

--- a/etc/turin-ruby-1.0.0.3.efs.json5
+++ b/etc/turin-ruby-1.0.0.3.efs.json5
@@ -12161,6 +12161,21 @@
                     },
                     {
                       Byte: {
+                        MemMbistDataEyeSilentExecutionDdr: "Disabled"
+                      }
+                    },
+                    {
+                      Byte: {
+                        BdatSupport: "Enabled"
+                      }
+                    },
+                    {
+                      Byte: {
+                        BdatPrintData: "Disabled"
+                      }
+                    },
+                    {
+                      Byte: {
                         FchI2cI3cSmbusSelect0: "I2c"
                       }
                     },
@@ -12900,6 +12915,21 @@
                     {
                       Byte: {
                         MemMbistDdrMode: "Disabled"
+                      }
+                    },
+                    {
+                      Byte: {
+                        MemMbistDataEyeSilentExecutionDdr: "Disabled"
+                      }
+                    },
+                    {
+                      Byte: {
+                        BdatSupport: "Enabled"
+                      }
+                    },
+                    {
+                      Byte: {
+                        BdatPrintData: "Disabled"
                       }
                     },
                     {

--- a/etc/turin-ruby-1.0.0.4.efs.json5
+++ b/etc/turin-ruby-1.0.0.4.efs.json5
@@ -12170,6 +12170,21 @@
                     },
                     {
                       Byte: {
+                        MemMbistDataEyeSilentExecutionDdr: "Disabled"
+                      }
+                    },
+                    {
+                      Byte: {
+                        BdatSupport: "Enabled"
+                      }
+                    },
+                    {
+                      Byte: {
+                        BdatPrintData: "Disabled"
+                      }
+                    },
+                    {
+                      Byte: {
                         FchI2cI3cSmbusSelect0: "I2c"
                       }
                     },
@@ -12919,6 +12934,21 @@
                     {
                       Byte: {
                         MemMbistDdrMode: "Disabled"
+                      }
+                    },
+                    {
+                      Byte: {
+                        MemMbistDataEyeSilentExecutionDdr: "Disabled"
+                      }
+                    },
+                    {
+                      Byte: {
+                        BdatSupport: "Enabled"
+                      }
+                    },
+                    {
+                      Byte: {
+                        BdatPrintData: "Disabled"
                       }
                     },
                     {

--- a/etc/turin-rubyred-0.0.8.1.efs.json5
+++ b/etc/turin-rubyred-0.0.8.1.efs.json5
@@ -9046,6 +9046,21 @@
                       }
                     },
                     {
+                      Byte: {
+                        MemMbistDataEyeSilentExecutionDdr: "Disabled"
+                      }
+                    },
+                    {
+                      Byte: {
+                        BdatSupport: "Enabled"
+                      }
+                    },
+                    {
+                      Byte: {
+                        BdatPrintData: "Disabled"
+                      }
+                    },
+                    {
                       "Byte": {
                         "FchI2cI3cSmbusSelect0": "I2c"
                       }
@@ -9809,6 +9824,21 @@
                     {
                       "Byte": {
                         "MemMbistDdrMode": "Disabled"
+                      }
+                    },
+                    {
+                      Byte: {
+                        MemMbistDataEyeSilentExecutionDdr: "Disabled"
+                      }
+                    },
+                    {
+                      Byte: {
+                        BdatSupport: "Enabled"
+                      }
+                    },
+                    {
+                      Byte: {
+                        BdatPrintData: "Disabled"
                       }
                     },
                     {

--- a/etc/turin-rubyred-1.0.0.1-p1.efs.json5
+++ b/etc/turin-rubyred-1.0.0.1-p1.efs.json5
@@ -8912,6 +8912,21 @@
                     },
                     {
                       Byte: {
+                        MemMbistDataEyeSilentExecutionDdr: "Disabled"
+                      }
+                    },
+                    {
+                      Byte: {
+                        BdatSupport: "Enabled"
+                      }
+                    },
+                    {
+                      Byte: {
+                        BdatPrintData: "Disabled"
+                      }
+                    },
+                    {
+                      Byte: {
                         FchI2cI3cSmbusSelect0: "I2c"
                       }
                     },
@@ -9675,6 +9690,21 @@
                     {
                       Byte: {
                         MemMbistDdrMode: "Disabled"
+                      }
+                    },
+                    {
+                      Byte: {
+                        MemMbistDataEyeSilentExecutionDdr: "Disabled"
+                      }
+                    },
+                    {
+                      Byte: {
+                        BdatSupport: "Enabled"
+                      }
+                    },
+                    {
+                      Byte: {
+                        BdatPrintData: "Disabled"
                       }
                     },
                     {

--- a/etc/turin-rubyred-1.0.0.2-p1.efs.json5
+++ b/etc/turin-rubyred-1.0.0.2-p1.efs.json5
@@ -12270,6 +12270,21 @@
                     },
                     {
                       Byte: {
+                        MemMbistDataEyeSilentExecutionDdr: "Disabled"
+                      }
+                    },
+                    {
+                      Byte: {
+                        BdatSupport: "Enabled"
+                      }
+                    },
+                    {
+                      Byte: {
+                        BdatPrintData: "Disabled"
+                      }
+                    },
+                    {
+                      Byte: {
                         FchI2cI3cSmbusSelect0: "I2c"
                       }
                     },
@@ -13054,6 +13069,21 @@
                     {
                       Byte: {
                         MemMbistDdrMode: "Disabled"
+                      }
+                    },
+                    {
+                      Byte: {
+                        MemMbistDataEyeSilentExecutionDdr: "Disabled"
+                      }
+                    },
+                    {
+                      Byte: {
+                        BdatSupport: "Enabled"
+                      }
+                    },
+                    {
+                      Byte: {
+                        BdatPrintData: "Disabled"
                       }
                     },
                     {


### PR DESCRIPTION
For completeness I also added `BdatPrintData` & `MemMbistDataEyeSilentExecutionDdr` which are related and might be useful for anyone trying to figure out the explicit state. They are left as `Disabled`.