### PR TITLE
[milan] Switch to raw unknown token value for setting AblSerialBaudRate.

### DIFF
--- a/etc/milan-ethanol-x-1.0.0.9-mbist.efs.json5
+++ b/etc/milan-ethanol-x-1.0.0.9-mbist.efs.json5
@@ -5354,8 +5354,12 @@
 											}
 										},
 										{
-											Byte: {
-												AblSerialBaudRate: "3000000 Baud"
+											Unknown: {
+												entry_id: "Byte",
+												// AblSerialBaudRate
+												tag: 0xAE46CEA4,
+												// 3000000 Baud - Milan Fast Spew ABL
+												value: 9
 											}
 										},
 										{

--- a/etc/milan-gimlet-b-1.0.0.9-mbist.efs.json5
+++ b/etc/milan-gimlet-b-1.0.0.9-mbist.efs.json5
@@ -5359,8 +5359,12 @@
 											}
 										},
 										{
-											Byte: {
-												AblSerialBaudRate: "3000000 Baud"
+											Unknown: {
+												entry_id: "Byte",
+												// AblSerialBaudRate
+												tag: 0xAE46CEA4,
+												// 3000000 Baud - Milan Fast Spew ABL
+												value: 9
 											}
 										},
 										{


### PR DESCRIPTION
The nice "3000000 Baud" alias we currently have in `amd-apcb` relies on a custom ABL we had for Milan and conflicts in newer firmware. To keep the old Milan configs working once https://github.com/oxidecomputer/amd-apcb/pull/165 lands we switch to setting the raw token value here instead.