### PR TITLE
[cosmo] Bump max DDR speed to 3200MHz (DDR6400).

### DIFF
--- a/etc/turin-cosmo-1.0.0.3-p1.efs.json5
+++ b/etc/turin-cosmo-1.0.0.3-p1.efs.json5
@@ -7480,7 +7480,7 @@
                         0
                       ],
                       speeds: [
-                        3000,
+                        3200,
                         4401,
                         4401
                       ]
@@ -7501,91 +7501,7 @@
                         0
                       ],
                       speeds: [
-                        3000,
-                        4401,
-                        4401
-                      ]
-                    },
-                    {
-                      dimm_slots_per_channel: {
-                        Specific: {
-                          one_dimm: false,
-                          two_dimms: true,
-                          three_dimms: false,
-                          four_dimms: false,
-                        }
-                      },
-                      conditions: [
-                        1,
-                        1,
-                        0,
-                        0
-                      ],
-                      speeds: [
-                        2600,
-                        4401,
-                        4401
-                      ]
-                    },
-                    {
-                      dimm_slots_per_channel: {
-                        Specific: {
-                          one_dimm: false,
-                          two_dimms: true,
-                          three_dimms: false,
-                          four_dimms: false,
-                        }
-                      },
-                      conditions: [
-                        1,
-                        0,
-                        1,
-                        0
-                      ],
-                      speeds: [
-                        2600,
-                        4401,
-                        4401
-                      ]
-                    },
-                    {
-                      dimm_slots_per_channel: {
-                        Specific: {
-                          one_dimm: false,
-                          two_dimms: true,
-                          three_dimms: false,
-                          four_dimms: false,
-                        }
-                      },
-                      conditions: [
-                        2,
-                        2,
-                        0,
-                        0
-                      ],
-                      speeds: [
-                        2200,
-                        4401,
-                        4401
-                      ]
-                    },
-                    {
-                      dimm_slots_per_channel: {
-                        Specific: {
-                          one_dimm: false,
-                          two_dimms: true,
-                          three_dimms: false,
-                          four_dimms: false,
-                        }
-                      },
-                      conditions: [
-                        2,
-                        0,
-                        2,
-                        0
-                      ],
-                      speeds: [
-                        2000,
+                        3200,
                         4401,
                         4401
                       ]
@@ -7624,49 +7540,7 @@
                         0
                       ],
                       speeds: [
-                        3000,
-                        4401,
-                        4401
-                      ]
-                    },
-                    {
-                      dimm_slots_per_channel: {
-                        Specific: {
-                          one_dimm: false,
-                          two_dimms: true,
-                          three_dimms: false,
-                          four_dimms: false,
-                        }
-                      },
-                      conditions: [
-                        1,
-                        0,
-                        1,
-                        0
-                      ],
-                      speeds: [
-                        2600,
-                        4401,
-                        4401
-                      ]
-                    },
-                    {
-                      dimm_slots_per_channel: {
-                        Specific: {
-                          one_dimm: false,
-                          two_dimms: true,
-                          three_dimms: false,
-                          four_dimms: false,
-                        }
-                      },
-                      conditions: [
-                        2,
-                        0,
-                        2,
-                        0
-                      ],
-                      speeds: [
-                        2000,
+                        3200,
                         4401,
                         4401
                       ]
@@ -9917,90 +9791,6 @@
                       ],
                       speeds: [
                         3200,
-                        4401,
-                        4401
-                      ]
-                    },
-                    {
-                      dimm_slots_per_channel: {
-                        Specific: {
-                          one_dimm: false,
-                          two_dimms: true,
-                          three_dimms: false,
-                          four_dimms: false,
-                        }
-                      },
-                      conditions: [
-                        1,
-                        1,
-                        0,
-                        0
-                      ],
-                      speeds: [
-                        2600,
-                        4401,
-                        4401
-                      ]
-                    },
-                    {
-                      dimm_slots_per_channel: {
-                        Specific: {
-                          one_dimm: false,
-                          two_dimms: true,
-                          three_dimms: false,
-                          four_dimms: false,
-                        }
-                      },
-                      conditions: [
-                        1,
-                        0,
-                        1,
-                        0
-                      ],
-                      speeds: [
-                        2600,
-                        4401,
-                        4401
-                      ]
-                    },
-                    {
-                      dimm_slots_per_channel: {
-                        Specific: {
-                          one_dimm: false,
-                          two_dimms: true,
-                          three_dimms: false,
-                          four_dimms: false,
-                        }
-                      },
-                      conditions: [
-                        2,
-                        2,
-                        0,
-                        0
-                      ],
-                      speeds: [
-                        2200,
-                        4401,
-                        4401
-                      ]
-                    },
-                    {
-                      dimm_slots_per_channel: {
-                        Specific: {
-                          one_dimm: false,
-                          two_dimms: true,
-                          three_dimms: false,
-                          four_dimms: false,
-                        }
-                      },
-                      conditions: [
-                        2,
-                        0,
-                        2,
-                        0
-                      ],
-                      speeds: [
-                        2000,
                         4401,
                         4401
                       ]


### PR DESCRIPTION
Bumps up the max speed in the `APCB_MEM_TYPE_PS_RDIMM_DDR5_MAX_FREQ` (`entry_id: 142`) and `APCB_MEM_TYPE_PS_3DS_RDIMM_DDR5_MAX_FREQ` (`entry_id: 148`) tables. `APCB_MEM_TYPE_PS_RDIMM_DDR5_MAX_FREQ_C1` (`entry_id: 163`) already had it at 3200.

Also went ahead and removed the 2DPC entries from all those tables since Cosmo is 1DPC.