### PR TITLE
filenames: extension logic fix

### DIFF
--- a/xtask/src/main.rs
+++ b/xtask/src/main.rs
@@ -9,6 +9,7 @@ use clap::Parser;
 use duct::cmd;
 use std::convert::From;
 use std::env;
+use std::ffi::OsString;
 use std::path::{Path, PathBuf};
 
 mod app;
@@ -231,9 +232,9 @@ fn run_gen<P: AsRef<Path> + ?Sized>(
     let mut config = if let Some(c) = config {
         PathBuf::from(c.as_ref())
     } else {
-        let mut c = PathBuf::from("etc").join(name);
-        c.set_extension("efs.json5");
-        c
+        let mut config = OsString::from(PathBuf::from("etc").join(name));
+        config.push(".efs.json5");
+        PathBuf::from(config)
     };
 
     if let Some(patch) = app.patch() {

--- a/xtask/src/main.rs
+++ b/xtask/src/main.rs
@@ -306,6 +306,7 @@ fn tests(args: Build) {
         .run()
         .expect("test successful");
     test_payload();
+    test_xgen_payload();
 }
 
 /// Runs the Clippy linter.
@@ -342,4 +343,28 @@ fn test_payload() {
         Build::default(),
     );
     dump(image, "target/test_blobs");
+}
+
+fn test_xgen_payload() {
+    let payload = "target/testpl";
+    let app = "apps/test.toml";
+    let image = "target/test.img";
+    let amd_firmware = "tests";
+    cmd(
+        cargo(),
+        [
+            "xtask",
+            "gen",
+            "--payload",
+            payload,
+            "--app",
+            app,
+            "--amd-firmware",
+            amd_firmware,
+            "--image",
+            image,
+        ],
+    )
+    .run()
+    .expect("cargo xtask gen successful");
 }


### PR DESCRIPTION
Sadly, `.set_extension` replaces a file name extension, it does not append, and newer interfaces to append extensions are not yet stable.  Anyway, this just modifies some logic so that we append the `.efs.json5` extension when constructing a config filename when not explicitly passing the path to the config.